### PR TITLE
Fixed top padding pushing the last credential slightly off the list

### DIFF
--- a/app/screens/HomeScreen/HomeScreen.styles.tsx
+++ b/app/screens/HomeScreen/HomeScreen.styles.tsx
@@ -3,7 +3,7 @@ import { mixins } from '../../styles';
 
 export default StyleSheet.create({
   container: {
-    padding: 16,
+    paddingHorizontal: 16,
   },
   header: {
     ...mixins.headerText,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179680726

This doesn't have the cleanest fix yet. The top and bottom padding now differ from the styles, but I do think that this is better.

To reproduce: scroll to the bottom of the credential list when you have enough credentials to have a scroll bar.

Before:
![image](https://user-images.githubusercontent.com/7339800/134600067-485525ed-904e-49e3-8020-d41daca3c232.png)

After:
![image](https://user-images.githubusercontent.com/7339800/134600043-8c464b9e-30c8-40d1-99ce-0efe48c6fbb6.png)
