### PR TITLE
Add logic for handling a deeplink in a QR code

### DIFF
--- a/app/screens/QRScreen/QRScreen.tsx
+++ b/app/screens/QRScreen/QRScreen.tsx
@@ -41,7 +41,29 @@ export default function QRScreen({ navigation }: QRScreenProps): JSX.Element {
 
     if (text.startsWith('dccrequest://request?')) {
       console.log('received deeplink via QR code', text);
-      const params: CredentialRequestParams = qs.parse(text.split('?')[1]);
+      const queryParams = qs.parse(text.split('?')[1]);
+      if (
+        !queryParams.vc_request_url
+        || !queryParams.issuer
+        || Array.isArray(queryParams.issuer)
+        || Array.isArray(queryParams.vc_request_url)
+        || Array.isArray(queryParams.auth_type)
+        || Array.isArray(queryParams.challenge)
+      ){
+        setErrorModalOpen(true);
+        setErrorMessage('The QR code contained an invalid deep link.');
+        return;
+      }
+      const params: CredentialRequestParams = {
+        issuer: queryParams.issuer,
+        vc_request_url: queryParams.vc_request_url,
+      };
+      if (queryParams.challenge){
+        params.challenge = queryParams.challenge;
+      }
+      if (queryParams.auth_type){
+        params.auth_type = queryParams.auth_type;
+      }
       navigation.navigate('AddScreen', params);
       return;
     }

--- a/app/screens/QRScreen/QRScreen.tsx
+++ b/app/screens/QRScreen/QRScreen.tsx
@@ -39,7 +39,7 @@ export default function QRScreen({ navigation }: QRScreenProps): JSX.Element {
       return;
     }
 
-    if (text.startsWith('dccrequest:request?')) {
+    if (text.startsWith('dccrequest://request?')) {
       console.log('received deeplink via QR code', text);
       const params: CredentialRequestParams = qs.parse(text.split('?')[1]);
       navigation.navigate('AddScreen', params);

--- a/app/screens/QRScreen/QRScreen.tsx
+++ b/app/screens/QRScreen/QRScreen.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import { View, useWindowDimensions } from 'react-native';
 import QRCodeScanner from 'react-native-qrcode-scanner';
 import { BarCodeReadEvent, RNCameraProps } from 'react-native-camera';
+import qs from 'query-string';
 
 import { PresentationError } from '../../types/presentation';
 import { ConfirmModal } from '../../components';
@@ -11,6 +12,7 @@ import { stageCredentials } from '../../store/slices/credentialFoyer';
 import { credentialsFromQrText, isVpqr } from '../../lib/decode';
 import { NavHeader } from '../../components';
 import { QRScreenProps } from './QRScreen.d';
+import { CredentialRequestParams } from '../../lib/request';
 import styles from './QRScreen.styles';
 
 export default function QRScreen({ navigation }: QRScreenProps): JSX.Element {
@@ -29,10 +31,18 @@ export default function QRScreen({ navigation }: QRScreenProps): JSX.Element {
   }
 
   async function onRead({ data: text }: BarCodeReadEvent) {
-    if (!isVpqr(text)) {
+    console.log('Read text from qrcode', text);
+    if (!isVpqr(text) && !text.startsWith('dccrequest:request?') ) {
       setErrorModalOpen(true);
       setErrorMessage('The QR code was read, but no credentials were found.');
+ 
+      return;
+    }
 
+    if (text.startsWith('dccrequest:request?')) {
+      console.log('received deeplink via QR code', text);
+      const params: CredentialRequestParams = qs.parse(text.split('?')[1]);
+      navigation.navigate('AddScreen', params);
       return;
     }
 

--- a/app/screens/QRScreen/QRScreen.tsx
+++ b/app/screens/QRScreen/QRScreen.tsx
@@ -32,7 +32,7 @@ export default function QRScreen({ navigation }: QRScreenProps): JSX.Element {
 
   async function onRead({ data: text }: BarCodeReadEvent) {
     console.log('Read text from qrcode', text);
-    if (!isVpqr(text) && !text.startsWith('dccrequest:request?') ) {
+    if (!isVpqr(text) && !text.startsWith('dccrequest://request?') ) {
       setErrorModalOpen(true);
       setErrorMessage('The QR code was read, but no credentials were found.');
  

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "moment": "^2.29.1",
         "patch-package": "^6.4.7",
         "process": "^0.11.10",
+        "query-string": "^7.1.0",
         "react": "16.13.1",
         "react-dom": "16.13.1",
         "react-native": "~0.63.4",
@@ -13406,9 +13407,9 @@
       }
     },
     "node_modules/query-string": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
-      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.0.tgz",
+      "integrity": "sha512-wnJ8covk+S9isYR5JIXPt93kFUmI2fQ4R/8130fuq+qwLiGVTurg7Klodgfw4NSz/oe7xnyi09y3lSrogUeM3g==",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -27669,9 +27670,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
-      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.0.tgz",
+      "integrity": "sha512-wnJ8covk+S9isYR5JIXPt93kFUmI2fQ4R/8130fuq+qwLiGVTurg7Klodgfw4NSz/oe7xnyi09y3lSrogUeM3g==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "moment": "^2.29.1",
     "patch-package": "^6.4.7",
     "process": "^0.11.10",
+    "query-string": "^7.1.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "~0.63.4",


### PR DESCRIPTION
See issue #97

This update detects a deeplink in a QR code and redirects to the AddScreen for the deeplink to be handled similarly to when a deeplink is clicked outside the app.

I don't think this is ready for merging. A few notes:

The deeplink needs to specify at least `vc_request_url`, `issuer` and `challenge` as params.

Currently an deeplink without the correct parameters will redirect to the add screen without any error (this probably also applies to links clicked outside the app).

The overall flow from adding a credential this way is different from adding a CBOR-LD QR Code, since the user will be redirected to an auth flow. I'm assuming that is the intended behavior?

For parsing query parameters I used 'query-string', this was already an indirect dependency.