### PR TITLE
Fixed duplicate credential logic

### DIFF
--- a/app/lib/validate.ts
+++ b/app/lib/validate.ts
@@ -50,7 +50,6 @@ export async function verifyCredential(credential: Credential): Promise<boolean>
       documentLoader,
     });
 
-    console.log(JSON.stringify(result));
     return result.verified;
   } catch (err) {
     console.warn(err);

--- a/app/store/slices/credentialFoyer.ts
+++ b/app/store/slices/credentialFoyer.ts
@@ -46,10 +46,10 @@ const initialState: CredentialFoyerState = {
 
 const stageCredentials = createAsyncThunk('credentialFoyer/stageCredentials', async (credentials: Credential[]) => {
   const existingCredentials = await CredentialRecord.getAllCredentials();
-  const existingCredentialIds = existingCredentials.map(({ credential }) => credential.id);
+  const existingCredentialProofValues = existingCredentials.map(({ credential }) => credential.proof?.proofValue);
   
   const pendingCredentials = credentials.map((credential) => {
-    if (existingCredentialIds.includes(credential.id)) {
+    if (existingCredentialProofValues.includes(credential.proof?.proofValue)) {
       return new PendingCredential(
         credential, 
         ApprovalStatus.Accepted, 


### PR DESCRIPTION
Fixes #80.

Not all credentials contain the `id` attribute.
The logic has been updated to use the `proofValue` to differentiate credentials.
