### PR TITLE
Updated add credential navigation

### DIFF
--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './useVerifyCredential';
 export * from './useRequestCredential';
 export * from './useAppLoading';
 export * from './useAccessibilityFocus';
+export * from './useResetNavigationOnBlur';

--- a/app/hooks/useResetNavigationOnBlur.ts
+++ b/app/hooks/useResetNavigationOnBlur.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+
+type GenericNavigation = {
+  setParams: (params: Record<string, unknown>) => void;
+}
+
+/**
+ * Hook for reseting navigational params on screen blur. Should be used in
+ * nested navigators that are being navigated to with a `screen` or `params`
+ * param.
+ * 
+ * Adapted from:
+ * https://github.com/react-navigation/react-navigation/issues/6915#issuecomment-591533068
+ */
+export function useResetNavigationOnBlur<Navigation extends GenericNavigation>(navigation: Navigation): void {
+  useFocusEffect(
+    useCallback(() => {
+      return () => navigation.setParams({ screen: undefined, params: undefined });
+    }, [navigation]),
+  );
+}

--- a/app/navigation/AddCredentialNavigation/AddCredentialNavigation.tsx
+++ b/app/navigation/AddCredentialNavigation/AddCredentialNavigation.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 
-import {
-  QRScreen,
-  AddScreen,
-  ApproveCredentialsScreen,
-  ApproveCredentialScreen,
-} from '../../screens';
-import type { AddCredentialNavigationParamList } from '../';
+import { QRScreen, AddScreen, ApproveCredentialsScreen, ApproveCredentialScreen } from '../../screens';
+import { useResetNavigationOnBlur } from '../../hooks';
+import type { AddCredentialNavigationParamList, AddCredentialNavigationProps } from '../';
 
 const Stack = createStackNavigator<AddCredentialNavigationParamList>();
 
-export default function AddCredentialNavigation(): JSX.Element {
+export default function AddCredentialNavigation({ navigation }: AddCredentialNavigationProps ): JSX.Element {
+  useResetNavigationOnBlur(navigation);
+
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name="AddScreen" component={AddScreen} />

--- a/app/screens/ApproveCredentialsScreen/ApproveCredentialsScreen.tsx
+++ b/app/screens/ApproveCredentialsScreen/ApproveCredentialsScreen.tsx
@@ -16,13 +16,13 @@ export default function ApproveCredentialsScreen({ navigation }: ApproveCredenti
     ({ credentialFoyer }) => credentialFoyer.pendingCredentials,
   );
 
-  function goToAdd() {
+  function goToHome() {
     if (navigationRef.isReady()) {
       navigationRef.navigate('HomeNavigation', { 
-        screen: 'AddCredentialNavigation', 
-        params: { 
-          screen: 'AddScreen', 
-        },
+        screen: 'CredentialNavigation',
+        params: {
+          screen: 'HomeScreen',
+        }, 
       });
     }
   }
@@ -32,7 +32,7 @@ export default function ApproveCredentialsScreen({ navigation }: ApproveCredenti
       <Button
         buttonStyle={styles.doneButton}
         titleStyle={styles.doneButtonTitle}
-        onPress={goToAdd}
+        onPress={goToHome}
         title="Done"
       />
     );


### PR DESCRIPTION
PT Story - [[FEATURE] Navigate back home after accepting credential](https://www.pivotaltracker.com/story/show/181052279)

Also fixed stale add credential navigation state issue. Commit description:
> In some cases when launching the app with a credential request, the stale navigation state would persist after navigating away and produce undefined behavior.
>
> This issue is fixed by reseting the state on blur.