### PR TITLE
Patched react-native-animated-ellipsis

### DIFF
--- a/patches/react-native-animated-ellipsis+2.0.0.patch
+++ b/patches/react-native-animated-ellipsis+2.0.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/react-native-animated-ellipsis/dist/AnimatedEllipsis.js b/node_modules/react-native-animated-ellipsis/dist/AnimatedEllipsis.js
+index 908626b..026dda8 100644
+--- a/node_modules/react-native-animated-ellipsis/dist/AnimatedEllipsis.js
++++ b/node_modules/react-native-animated-ellipsis/dist/AnimatedEllipsis.js
+@@ -47,7 +47,8 @@ export default class AnimatedEllipsis extends Component {
+ 
+     Animated.timing(this._animation_state.dot_opacities[which_dot], {
+       toValue: this._animation_state.target_opacity,
+-      duration: this.props.animationDelay
++      duration: this.props.animationDelay,
++      useNativeDriver: true,
+     }).start(this.animate_dots.bind(this, next_dot));
+   }
+ 


### PR DESCRIPTION
This resolves the library's current warning:
```
Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`
```