### PR TITLE
Fixed verification error handling

### DIFF
--- a/app/lib/request.ts
+++ b/app/lib/request.ts
@@ -60,10 +60,13 @@ export async function requestCredential(credentialRequestParams: CredentialReque
   const responseJson  = await response.json();
   const credential = responseJson as Credential;
 
-  const verified = await verifyCredential(credential);
-
-  if (!verified) {
-    console.warn('Credential was received, but could not be verified');
+  try {
+    const verified = await verifyCredential(credential);
+    if (!verified) {
+      throw new Error('Credential was received, but could not be verified');
+    }
+  } catch (err) {
+    console.warn(err);
   }
 
   return credential;


### PR DESCRIPTION
Fixes #122 

Wrapping the `verifyCredential` method in a try/catch, allows the credential to still be received if the method itself were to throw an error.

_The error will be passed to the console as a warning for now._