### PR TITLE
adds email scope to playground default oidc issuer

### DIFF
--- a/app/data/issuerAuth.ts
+++ b/app/data/issuerAuth.ts
@@ -20,7 +20,7 @@ export const issuerAuthRegistry: RegistryRaw<IssuerAuthEntry> = {
       issuer: 'https://kezike-oidc-provider.herokuapp.com',
       clientId: 'edu-wallet',
       redirectUrl: 'dccrequest://oauth',
-      scopes: ['openid', 'profile'],
+      scopes: ['openid', 'profile', 'email'],
     },
     'https://rc.xpro.mit.edu': {
       issuer: 'https://rc.xpro.mit.edu',


### PR DESCRIPTION
This PR adds `email` scope to default OIDC issuer used in DCC Playground