### PR TITLE
ensure did is created before transition to root navigation

### DIFF
--- a/app/hooks/useShareCredentials.ts
+++ b/app/hooks/useShareCredentials.ts
@@ -9,11 +9,7 @@ export function useShareCredentials(): (credentials: CredentialRecordRaw[]) => v
   const { rawDidRecords } = useSelector<RootState, DidState>(({ did }) => did);
 
   if (rawDidRecords.length === 0) {
-    return (credentials: CredentialRecordRaw[]) => {
-    };
-    // FIXME: This error gets thrown on first launch / wallet init -- probably
-    //   a lifecycle issue (this function gets called before DID init).
-    // throw new Error('No DID generated. Something went wrong in wallet initialization.');
+    throw new Error('No DID generated. Something went wrong in wallet initialization.');
   }
 
   const [ rawDidRecord ] = rawDidRecords;

--- a/app/store/slices/wallet.ts
+++ b/app/store/slices/wallet.ts
@@ -43,7 +43,7 @@ const unlock = createAsyncThunk('walletState/unlock', async (passphrase: string)
 const initialize = createAsyncThunk('walletState/initialize', async (passphrase: string, { dispatch }) => {
   await db.initialize(passphrase);
   await db.unlock(passphrase);
-  dispatch(mintDid());
+  await dispatch(mintDid());
 });
 
 const reset = createAsyncThunk('walletState/reset', async () => {


### PR DESCRIPTION
Fixes #146 

When the user clicks the "Take Me to My Wallet" button the wallet is initialized but the process of generating the DID is started asynchronously. This was causing the `isInitialized` field in the store to be set to true before DID generation was complete. This meant the app transitioned to the Home screen before the DID was generated, causing the exception to be thrown.

This fix ensures the DID generation is completed before transitioning to the home screen.