### PR TITLE
Updated request logic to receive verifiable presentations 

### DIFF
--- a/app/components/CredentialCard/CredentialCard.styles.tsx
+++ b/app/components/CredentialCard/CredentialCard.styles.tsx
@@ -34,6 +34,7 @@ export default StyleSheet.create({
     fontFamily: theme.fontFamily.regular,
     fontSize: theme.fontSize.regular,
     color: theme.color.textPrimary,
+    flex: 1,
   },
   link: {
     fontFamily: theme.fontFamily.regular,

--- a/app/hooks/useRequestCredential.ts
+++ b/app/hooks/useRequestCredential.ts
@@ -8,7 +8,7 @@ import { DidState } from '../store/slices/did';
 import { Credential } from '../types/credential';
 
 export type RequestPayload = {
-  credential?: Credential;
+  credentials?: Credential[];
   loading: boolean;
   error: string;
 }
@@ -20,11 +20,11 @@ function isCredentialRequestParams(params?: Params): params is CredentialRequest
   return issuer !== undefined && vc_request_url !== undefined;
 }
 
-export function useRequestCredential(routeParams?: Params): RequestPayload {
+export function useRequestCredentials(routeParams?: Params): RequestPayload {
   const { rawDidRecords } = useSelector<RootState, DidState>(({ did }) => did);
   const [ didRecord ] = rawDidRecords;
 
-  const [credential, setCredential] = useState<Credential | undefined>();
+  const [credentials, setCredentials] = useState<Credential[] | undefined>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -41,10 +41,10 @@ export function useRequestCredential(routeParams?: Params): RequestPayload {
       setLoading(true);
 
       try {
-        const credential = await requestCredential(routeParams, didRecord);
-        setCredential(credential);
+        const credentials = await requestCredential(routeParams, didRecord);
+        setCredentials(credentials);
       } catch (err) {
-        setError(err.message);
+        setError((err as Error).message);
       } finally {
         setLoading(false);
       }
@@ -56,5 +56,5 @@ export function useRequestCredential(routeParams?: Params): RequestPayload {
     handleDeepLink();
   }, [routeParams, didRecord]);
 
-  return { credential, loading, error };
+  return { credential: credentials, loading, error };
 }

--- a/app/hooks/useRequestCredential.ts
+++ b/app/hooks/useRequestCredential.ts
@@ -56,5 +56,5 @@ export function useRequestCredentials(routeParams?: Params): RequestPayload {
     handleDeepLink();
   }, [routeParams, didRecord]);
 
-  return { credential: credentials, loading, error };
+  return { credentials, loading, error };
 }

--- a/app/hooks/useRequestCredential.ts
+++ b/app/hooks/useRequestCredential.ts
@@ -29,7 +29,7 @@ export function useRequestCredentials(routeParams?: Params): RequestPayload {
   const [error, setError] = useState('');
 
   /**
-   * The app takes a few miliseconds to update the DID store when the app is launched
+   * The app takes a few milliseconds to update the DID store when the app is launched
    * with a deep link request, so we should wait until the didRecord is
    * present before handling a deep link and ensure that the splash screen is
    * hidden.

--- a/app/lib/parseResponse.ts
+++ b/app/lib/parseResponse.ts
@@ -1,0 +1,10 @@
+import * as HtmlEntities from 'html-entities';
+
+export async function parseResponseBody(response: Response): Promise<Record<string, unknown>> {
+  const responseText = await response.text();
+  const responseTextDecoded = HtmlEntities.decode(responseText);
+  const responseJson = JSON.parse(responseTextDecoded);
+
+  return responseJson;
+}
+

--- a/app/lib/request.ts
+++ b/app/lib/request.ts
@@ -9,7 +9,7 @@ import { verifyCredential } from './validate';
 import { registries } from './registry';
 
 export type CredentialRequestParams = {
-  auth_type?: string;
+  auth_type?: 'code' | 'bearer';
   issuer: string;
   vc_request_url: string;
   challenge?: string;
@@ -17,18 +17,18 @@ export type CredentialRequestParams = {
 
 export async function requestCredential(credentialRequestParams: CredentialRequestParams, didRecord: DidRecordRaw): Promise<Credential> {
   const {
+    auth_type = 'code',
     issuer,
     vc_request_url,
     challenge,
   } = credentialRequestParams;
-  // Default to 'code' - OAuth2 Authorization Code flow
-  const authType = credentialRequestParams.auth_type || 'code';
+ 
   console.log('Credential request params', credentialRequestParams);
 
   let accessToken;
   let oidcConfig;
 
-  switch (authType) {
+  switch (auth_type) {
   case 'code':
     if (!registries.issuerAuth.isInRegistry(issuer)) {
       throw new Error(`Unknown issuer: "${issuer}"`);
@@ -50,7 +50,7 @@ export async function requestCredential(credentialRequestParams: CredentialReque
     // Bearer token - do nothing. The 'challenge' param will be passed in the VP
     break;
   default:
-    throw Error(`Unsupported auth_type value: "${authType}".`);
+    throw Error(`Unsupported auth_type value: "${auth_type}".`);
   }
 
   const requestBody = await createVerifiablePresentation(

--- a/app/lib/request.ts
+++ b/app/lib/request.ts
@@ -82,7 +82,7 @@ export async function requestCredential(credentialRequestParams: CredentialReque
   const responseBody = await parseResponseBody(response);
   const verifiableObject = responseBody as VerifiableObject;
 
-  const verified = verifyVerifiableObject(verifiableObject);
+  const verified = await verifyVerifiableObject(verifiableObject);
   if (!verified) {
     console.warn('Response was received, but could not be verified');
   }

--- a/app/lib/request.ts
+++ b/app/lib/request.ts
@@ -9,7 +9,7 @@ import { parseResponseBody } from './parseResponse';
 import { extractCredentialsFrom, verifyVerifiableObject, VerifiableObject } from './verifiableObject';
 
 export type CredentialRequestParams = {
-  auth_type?: 'code' | 'bearer';
+  auth_type?: string;
   issuer: string;
   vc_request_url: string;
   challenge?: string;

--- a/app/lib/request.ts
+++ b/app/lib/request.ts
@@ -1,5 +1,4 @@
 import { authorize } from 'react-native-app-auth';
-import * as HtmlEntities from 'html-entities';
 
 import { Credential } from '../types/credential';
 import { DidRecordRaw } from '../model';
@@ -7,6 +6,7 @@ import { DidRecordRaw } from '../model';
 import { createVerifiablePresentation } from './present';
 import { verifyCredential } from './validate';
 import { registries } from './registry';
+import { parseResponseBody } from './parseResponse';
 
 export type CredentialRequestParams = {
   auth_type?: 'code' | 'bearer';
@@ -79,9 +79,8 @@ export async function requestCredential(credentialRequestParams: CredentialReque
     throw Error('Unable to receive credential: The issuer failed to return a valid response');
   }
 
-  const responseText = await response.text();
-  const responseTextDecoded = HtmlEntities.decode(responseText);
-  const responseJson = JSON.parse(responseTextDecoded);
+  const responseBody = await parseResponseBody(response);
+  const verifiableObject = responseBody as VerifiableObject;
 
   const credential = responseJson as Credential;
 

--- a/app/lib/verifiableObject.ts
+++ b/app/lib/verifiableObject.ts
@@ -16,14 +16,15 @@ function isVerifiablePresentation(obj: VerifiableObject): obj is VerifiablePrese
   return obj.type.includes('VerifiablePresentation');
 }
 
-export async function verifyVerifiableObject(obj: VerifiableObject): Promise<boolean | void> {
+export async function verifyVerifiableObject(obj: VerifiableObject): Promise<boolean> {
   try {
-    if (isVerifiableCredential(obj)) return verifyCredential(obj);
-    if (isVerifiablePresentation(obj)) return verifyPresentation(obj);
+    if (isVerifiableCredential(obj)) return await verifyCredential(obj);
+    if (isVerifiablePresentation(obj)) return await verifyPresentation(obj);
   } catch (err) {
     console.warn(err);
-    return false;
   }
+
+  return false;
 }
 
 export function extractCredentialsFrom(obj: VerifiableObject): Credential[] | null {

--- a/app/lib/verifiableObject.ts
+++ b/app/lib/verifiableObject.ts
@@ -1,0 +1,44 @@
+import { Credential } from '../types/credential';
+import { VerifiablePresentation } from '../types/presentation';
+import { verifyCredential, verifyPresentation } from './validate';
+
+/**
+ * This type is used to identify a request response that could be a 
+ * Verifiable Credential or Verifiable Presentation.
+ */
+export type VerifiableObject = Credential | VerifiablePresentation;
+
+function isVerifiableCredential(obj: VerifiableObject): obj is Credential {
+  return obj.type?.includes('VerifiableCredential');
+}
+
+function isVerifiablePresentation(obj: VerifiableObject): obj is VerifiablePresentation {
+  return obj.type.includes('VerifiablePresentation');
+}
+
+export async function verifyVerifiableObject(obj: VerifiableObject): Promise<boolean | void> {
+  try {
+    if (isVerifiableCredential(obj)) return verifyCredential(obj);
+    if (isVerifiablePresentation(obj)) return verifyPresentation(obj);
+  } catch (err) {
+    console.warn(err);
+    return false;
+  }
+}
+
+export function extractCredentialsFrom(obj: VerifiableObject): Credential[] | null {
+  if (isVerifiableCredential(obj)) {
+    return [obj];
+  }
+
+  if (isVerifiablePresentation(obj)) {
+    const { verifiableCredential } = obj;
+
+    if (verifiableCredential instanceof Array) {
+      return verifiableCredential;
+    }
+    return [verifiableCredential];
+  }
+
+  return null;
+}

--- a/app/screens/AddScreen/AddScreen.tsx
+++ b/app/screens/AddScreen/AddScreen.tsx
@@ -9,7 +9,7 @@ import { theme, mixins } from '../../styles';
 import styles from './AddScreen.styles';
 import { AddScreenProps } from './AddScreen.d';
 import { stageCredentials } from '../../store/slices/credentialFoyer';
-import { useRequestCredential } from '../../hooks';
+import { useRequestCredentials } from '../../hooks';
 import { ConfirmModal, NavHeader } from '../../components';
 
 
@@ -17,7 +17,7 @@ export default function AddScreen({ navigation, route }: AddScreenProps): JSX.El
   const [requestModalIsOpen, setRequestModalIsOpen] = useState(false);
   const dispatch = useDispatch();
 
-  const { credential, error, loading } = useRequestCredential(route.params);
+  const { credentials, error, loading } = useRequestCredentials(route.params);
 
   useEffect(() => {
     if (loading) {
@@ -30,12 +30,12 @@ export default function AddScreen({ navigation, route }: AddScreenProps): JSX.El
       });
     }
 
-    if (credential) {
+    if (credentials) {
       setRequestModalIsOpen(false);
-      dispatch(stageCredentials([credential]));
+      dispatch(stageCredentials(credentials));
       navigation.navigate('ApproveCredentialsScreen');
     }
-  }, [credential, loading]);
+  }, [credentials, loading]);
 
   return (
     <>


### PR DESCRIPTION
GitHub Issue - #162
PT Story - https://www.pivotaltracker.com/story/show/181662018

### Solution Overview
- Created the type `VerifiableObject` to identify a response that could be a VC or VP.
- Added lib methods to handle operations for that union type.
- Updated request payload type to support multiple credentials.