### PR TITLE
Update registry to load issuer DID registry from a URL

### DIFF
--- a/app/lib/registry.ts
+++ b/app/lib/registry.ts
@@ -31,10 +31,45 @@ class Registry<Entry> implements RegistryRaw<Entry> {
 
     return this.entries[key];
   }
+}
 
+class RemoteRegistry<Entry> implements RegistryRaw<Entry> {
+  readonly meta;
+  readonly entries;
+
+  constructor(url: string) {
+    this.registryUrl = url;
+  }
+
+  private async fetchRegistry(){
+    console.log(`RemoteRegistry.fetchRegistry(url=${this.registryUrl})`);
+    const response = await fetch(this.registryUrl);
+    if (!response.ok) {
+      console.log(`RemoteRegistry.fetchRegistry(url=${this.registryUrl}) failed`);
+      throw Error('Unable to fetch remote registry')
+    }
+    const data = await response.json();
+    console.log(JSON.stringify(data));
+    this.meta = data.meta;
+    this.entries = data.registry;
+  }
+
+  public async isInRegistry(key: string): boolean {
+    await this.fetchRegistry();
+    return key in this.entries;
+  }
+
+  public async entryFor(key: string): boolean {
+    await this.fetchRegistry();
+    if (!this.isInRegistry(key)) {
+      throw new Error(`${key} not found in registry.`);
+    }
+
+    return this.entries[key];
+  }
 }
 
 export const registries = {
-  issuerDid: new Registry<IssuerDidEntry>(issuerDidRegistry),
+  issuerDid: new RemoteRegistry<IssuerDidEntry>('https://raw.githubusercontent.com/digitalcredentials/issuer-registry/main/registry.json'),
   issuerAuth: new Registry<IssuerAuthEntry>(issuerAuthRegistry),
 };

--- a/app/lib/validate.ts
+++ b/app/lib/validate.ts
@@ -39,7 +39,7 @@ export async function verifyCredential(credential: Credential): Promise<boolean>
 
   const issuerDid = typeof issuer === 'string' ? issuer : issuer.id;
 
-  if (!registries.issuerDid.isInRegistry(issuerDid)) {
+  if (!await registries.issuerDid.isInRegistry(issuerDid)) {
     throw new Error(CredentialError.DidNotInRegistry);
   }
 


### PR DESCRIPTION
I did a quick update to load the issuer DID registry as per  #173. 

I'm not sold on the abstraction used in [app/lib/registry.ts](https://github.com/digitalcredentials/learner-credential-wallet/blob/remote-registry/app/lib/registry.ts#L73-L74) - the type specifies two readonly attributes, but that data is only ever used through `isInRegistry` and `entryFor`. 

With this change, [issuerDid and issuerAuth](https://github.com/digitalcredentials/learner-credential-wallet/blob/remote-registry/app/lib/registry.ts#L73-L74) has in inconsistent interface. since the one is async and the other one isn't.

Also, I couldn't get the app to run correctly without reverting the changes in 7c2ebf4156a034ef8924d7c01d254aa81c02d498. It doesn't look like it should break anything, but maybe the requirement did something to cause the issue? I didn't include the reversion in this branch.

@dmitrizagidulin let me know what you think and if I should change anything



