### PR TITLE
load did and credentials when unlocking the wallet

### DIFF
--- a/app/store/slices/wallet.ts
+++ b/app/store/slices/wallet.ts
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
-import { mintDid } from './did';
+import { getAllDidRecords, mintDid } from './did';
 import {
   db,
   CredentialRecord,
@@ -36,8 +36,10 @@ const lock = createAsyncThunk('walletState/lock', async () => {
   await db.lock();
 });
 
-const unlock = createAsyncThunk('walletState/unlock', async (passphrase: string) => {
+const unlock = createAsyncThunk('walletState/unlock', async (passphrase: string, { dispatch }) => {
   await db.unlock(passphrase);
+  await dispatch(getAllDidRecords());
+  await dispatch(getAllCredentials());
 });
 
 const initialize = createAsyncThunk('walletState/initialize', async (passphrase: string, { dispatch }) => {


### PR DESCRIPTION
App startup only loaded DIDs and credentials if the wallet was already unlocked upon launching the app. This fix causes the DIDs and Credentials to be loaded when the user unlocks the app if the wallet is locked on launch.