### PR TITLE
Fixed backup error on Android

### DIFF
--- a/app/components/ConfirmModal/ConfirmModal.tsx
+++ b/app/components/ConfirmModal/ConfirmModal.tsx
@@ -7,6 +7,13 @@ import { useAccessibilityFocus } from '../../hooks';
 
 import styles from './ConfirmModal.style';
 
+/** 
+ * TODO: Right now the accessibility focus throws errors on Android 
+ * when returning from the share UI. Those errors must be resolved before
+ * this can be enabled. This disable flag is a temporary fix.
+ */ 
+const ENABLE_ACCESSIBILITY_FOCUS = false;
+
 export type ConfirmModalProps = React.PropsWithChildren<{
   open?: boolean;
 
@@ -53,7 +60,9 @@ export default function ConfirmModal({
   }, [open]);
 
   function onContentLayout() {
-    accessibilityFocusContent ? focusContent() : focusTitle();
+    if (ENABLE_ACCESSIBILITY_FOCUS) {
+      accessibilityFocusContent ? focusContent() : focusTitle();
+    }
   }
 
   return (

--- a/app/screens/ManageProfilesScreen/ManageProfilesScreen.tsx
+++ b/app/screens/ManageProfilesScreen/ManageProfilesScreen.tsx
@@ -13,7 +13,6 @@ import { createProfile } from '../../store/slices/profile';
 
 import { ManageProfilesScreenProps } from './ManageProfilesScreen.d';
 import styles from './ManageProfilesScreen.styles';
-import { ScrollView } from 'react-native-gesture-handler';
 
 export default function ManageProfilesScreen({ navigation }: ManageProfilesScreenProps): JSX.Element {
   const [profileName, setProfileName] = useState('');


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183275565

This PR disables accessibility focus on Android for the `ConfirmModal` component.
_This is temporary fix for the error throw while backing up the wallet. Further investigation should be done to adequately fix the issue._