### PR TITLE
[Rebased] fixes iOS build alongside Android CHAPI implementation

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -189,6 +189,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    implementation "org.glassfish:javax.json:1.1.4"
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,18 @@
           android:scheme="dccrequest"
           android:host="present"/>
       </intent-filter>
+      <!--TODO: Add this filter, if you want to support sharing text into your app-->
+      <intent-filter>
+        <action android:name="android.intent.action.SEND" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="text/*" />
+      </intent-filter>
+      <!--TODO: Add this filter, if you want to support sharing any type of files-->
+      <intent-filter>
+        <action android:name="android.intent.action.SEND" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="*/*" />
+      </intent-filter>
     </activity>
     <activity android:name="net.openid.appauth.RedirectUriReceiverActivity"
     tools:node="replace" android:exported="false">
@@ -48,26 +60,11 @@
         <category android:name="android.intent.category.BROWSABLE"/>
         <data android:scheme="com.googleusercontent.apps.511371443696-0gq71qbne41qc102m98qqv8fvs62kr0c" />
       </intent-filter>
-
-      <!--TODO: Add this filter, if you want to support sharing text into your app-->
-      <intent-filter>
-        <action android:name="android.intent.action.SEND" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <data android:mimeType="text/*" />
-      </intent-filter>
-
-      <!--TODO: Add this filter, if you want to support sharing any type of files-->
-      <intent-filter>
-        <action android:name="android.intent.action.SEND" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <data android:mimeType="*/*" />
-      </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.SEND_MULTIPLE" />
         <category android:name="android.intent.category.DEFAULT" />
         <data android:mimeType="*/*" />
       </intent-filter>
-
     </activity>
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false" />
   </application>

--- a/android/app/src/main/java/app/lcw/LCWReceiveModule.java
+++ b/android/app/src/main/java/app/lcw/LCWReceiveModule.java
@@ -1,0 +1,138 @@
+package app.lcw;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.util.Log;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+public class LCWReceiveModule extends ReactContextBaseJavaModule {
+  // Events
+  private final String CredentialReceivedEventKey = "CREDENTIAL_RECEIVED_EVENT";
+  private final String CredentialReceivedEventValue = "credential_received";
+  private final String DidAuthReceivedEventKey = "DID_AUTH_RECEIVED_EVENT";
+  private final String DidAuthReceivedEventValue = "did_auth_received";
+
+  // Data
+  private final String CredentialKey = "CREDENTIAL";
+  private final String CredentialValue = "credential";
+  private final String DidAuthKey = "DID_AUTH";
+  private final String DidAuthValue = "did_auth";
+
+  // React
+  private final ReactApplicationContext reactContext;
+
+  LCWReceiveModule(ReactApplicationContext context) {
+    super(context);
+    this.reactContext = context;
+  }
+
+  @Override
+  public String getName() {
+    return "LCWReceiveModule";
+  }
+
+  @Override
+  public Map<String, Object> getConstants() {
+    final Map<String, Object> constants = new HashMap<>();
+    constants.put(CredentialReceivedEventKey, CredentialReceivedEventValue);
+    constants.put(DidAuthReceivedEventKey, DidAuthReceivedEventValue);
+    constants.put(CredentialKey, CredentialValue);
+    constants.put(DidAuthKey, DidAuthValue);
+    return constants;
+  }
+
+  private void processData(JsonObject dataObject) {
+    // Create map for data
+    WritableMap payload = Arguments.createMap();
+
+    // Get data directory
+    File filesDir = this.reactContext.getFilesDir();
+
+    try {
+      if (dataObject.containsKey("credential")) {
+        // Verifiable credential
+        // Extract credential from data
+        JsonObject data = dataObject.getJsonObject("credential")
+                                    .getJsonObject("data")
+                                    .getJsonArray("verifiableCredential")
+                                    .getJsonObject(0);
+        payload.putString(CredentialValue, data.toString());
+        this.reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit(CredentialReceivedEventValue, payload);
+      } else {
+        // DID Authentication
+        // Extract did auth request from data
+        JsonObject data = dataObject.getJsonObject("credentialRequestOptions")
+                                    .getJsonObject("web")
+                                    .getJsonObject("VerifiablePresentation");
+        payload.putString(DidAuthValue, data.toString());
+        this.reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit(DidAuthReceivedEventValue, payload);
+      }
+    } catch (JsonException | IllegalStateException | ClassCastException e) {
+      Log.e("LCWReceiveModule.processData.error", e.getMessage());
+      return;
+    }
+  }
+
+  @ReactMethod
+  public void getData() {
+    // Get current intent
+    Intent intent = getCurrentActivity().getIntent();
+
+    // Get action and type
+    String action = intent.getAction();
+    String type = intent.getType();
+
+    // Only handle receiving a single text file for now
+    if (!Intent.ACTION_SEND.equals(action) || !type.startsWith("text/")) {
+      return;
+    }
+
+    try {
+      // Retrieve data streamed from external application
+      Uri dataUri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
+      InputStream dataStream = this.reactContext.getContentResolver().openInputStream(dataUri);
+
+      // Parse data into json
+      JsonReader dataReader = Json.createReader(dataStream);
+      JsonObject dataObject = dataReader.readObject();
+      this.processData(dataObject);
+
+      // Clear intent action after retrieving data, so as not to trigger
+      // this function unecessarily on each active app state (see MainActivity#onNewIntent)
+      intent.setAction(null)
+               .setType(null);
+    } catch (IOException e) {
+      Log.e("LCWReceiveModule.getData.error", e.getMessage());
+      return;
+    }
+  }
+
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
+}

--- a/android/app/src/main/java/app/lcw/LCWReceivePackage.java
+++ b/android/app/src/main/java/app/lcw/LCWReceivePackage.java
@@ -1,0 +1,24 @@
+package app.lcw;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class LCWReceivePackage implements ReactPackage {
+  @Override
+  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+    modules.add(new LCWReceiveModule(reactContext));
+    return modules;
+  }
+}

--- a/android/app/src/main/java/app/lcw/MainApplication.java
+++ b/android/app/src/main/java/app/lcw/MainApplication.java
@@ -42,6 +42,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       List<ReactPackage> packages = new PackageList(this).getPackages();
       packages.add(new ModuleRegistryAdapter(mModuleRegistryProvider));
+      packages.add(new LCWReceivePackage());
       return packages;
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,17 @@ buildscript {
 
 allprojects {
     repositories {
+        exclusiveContent {
+            filter {
+                includeGroup "com.facebook.react"
+            }
+            forRepository {
+                maven {
+                    url "$rootDir/../node_modules/react-native/android"
+                }
+            }
+       }
+
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useSelectorFactory';
 export * from './useAppDispatch';
 export * from './useThemeContext';
 export * from './useDynamicStyles';
+export * from './useLCWReceiveModule';

--- a/app/hooks/useLCWReceiveModule.tsx
+++ b/app/hooks/useLCWReceiveModule.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect } from 'react';
+import { AppState, NativeEventEmitter, NativeModule, NativeModules, Platform, Text } from 'react-native';
+import { LoadingIndicatorDots } from '../components';
+import { performDidAuthRequest } from '../lib/didAuthRequest';
+import { clearGlobalModal, displayGlobalModal } from '../lib/globalModal';
+import { NavigationUtil } from '../lib/navigationUtil';
+import { navigationRef } from '../navigation';
+import { stageCredentials } from '../store/slices/credentialFoyer';
+import { useAppDispatch } from './useAppDispatch';
+import { useDynamicStyles } from './useDynamicStyles';
+
+type LCWReceiveModule = NativeModule & {
+  getConstants: () => LCWReceiveModuleConstants;
+  getData: () => void;
+}
+
+type LCWReceiveModuleConstants = {
+  CREDENTIAL_RECEIVED_EVENT: string;
+  DID_AUTH_RECEIVED_EVENT: string;
+  CREDENTIAL: string;
+  DID_AUTH: string;
+}
+
+type LCWReceiveModuleEvent = Record<string, string>;
+
+let LCWReceiveModule: LCWReceiveModule;
+let CREDENTIAL_RECEIVED_EVENT: string;
+let DID_AUTH_RECEIVED_EVENT: string;
+let CREDENTIAL: string;
+let DID_AUTH: string;
+
+if (Platform.OS === 'android') {
+  LCWReceiveModule = NativeModules.LCWReceiveModule;
+  const constants = LCWReceiveModule.getConstants();
+  CREDENTIAL_RECEIVED_EVENT = constants.CREDENTIAL_RECEIVED_EVENT;
+  DID_AUTH_RECEIVED_EVENT = constants.DID_AUTH_RECEIVED_EVENT;
+  CREDENTIAL = constants.CREDENTIAL;
+  DID_AUTH = constants.DID_AUTH;
+}
+
+export function useLCWReceiveModule(): void {
+  const dispatch = useAppDispatch();
+  const { mixins } = useDynamicStyles();
+
+  const dataLoadingModalState = {
+    title: 'Retrieving Credential',
+    confirmButton: false,
+    cancelButton: false,
+    body: (
+      <>
+        <Text style={mixins.modalBodyText}>
+          This will only take a moment.
+        </Text>
+        <LoadingIndicatorDots />
+      </>
+    )
+  };
+
+  const onCredentialReceived = async (event: LCWReceiveModuleEvent) => {
+    displayGlobalModal(dataLoadingModalState);
+    const credentialString = event[CREDENTIAL];
+    const credential = JSON.parse(credentialString);
+    clearGlobalModal();
+
+    await dispatch(stageCredentials([credential]));
+    const rawProfileRecord = await NavigationUtil.selectProfile();
+
+    if (navigationRef.isReady()) {
+      navigationRef.navigate('AcceptCredentialsNavigation', { 
+        screen: 'ApproveCredentialsScreen',
+        params: {
+          rawProfileRecord,
+        }
+      });
+    }
+  };
+
+  const onDidAuthReceived = async (event: LCWReceiveModuleEvent) => {
+    displayGlobalModal(dataLoadingModalState);
+    const didAuthString = event[DID_AUTH];
+    const didAuthRequest = JSON.parse(didAuthString);
+
+    if (navigationRef.isReady()) {
+      clearGlobalModal();
+      const rawProfileRecord = await NavigationUtil.selectProfile();
+      await performDidAuthRequest(didAuthRequest, rawProfileRecord);
+
+      navigationRef.navigate('AcceptCredentialsNavigation',{
+        screen: 'ApproveCredentialsScreen',
+        params: {  
+          rawProfileRecord,
+        }
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (Platform.OS === 'android') {
+      const eventEmitter = new NativeEventEmitter(LCWReceiveModule);
+      const credentialSubscription = eventEmitter.addListener(
+        CREDENTIAL_RECEIVED_EVENT,
+        onCredentialReceived
+      );
+      const didSubscription = eventEmitter.addListener(
+        DID_AUTH_RECEIVED_EVENT,
+        onDidAuthReceived
+      );
+    
+      const appStateSubscription = AppState.addEventListener(
+        'change',
+        (state) => {
+          if (state === 'active') {
+            LCWReceiveModule.getData();
+          }
+        }
+      );
+
+      return () => {
+        credentialSubscription.remove();
+        didSubscription.remove();
+        appStateSubscription.remove();
+      };
+    }
+  }, []);
+}

--- a/app/lib/didAuthRequest.ts
+++ b/app/lib/didAuthRequest.ts
@@ -1,0 +1,48 @@
+import { ProfileRecordRaw } from '../model';
+import { makeSelectDidFromProfile, selectWithFactory } from '../store/selectorFactories';
+import { Ed25519Signature2020 } from '@digitalcredentials/ed25519-signature-2020';
+import { Ed25519VerificationKey2020 } from '@digitalcredentials/ed25519-verification-key-2020';
+import { constructExchangeRequest, handleVcApiExchange } from './exchanges';
+import store from '../store';
+import { stageCredentials } from '../store/slices/credentialFoyer';
+import { extractCredentialsFrom } from './verifiableObject';
+
+type VerifiablePresentationRequestService = {
+  type: string;
+  serviceEndpoint: string;
+}
+
+export type DidAuthRequestParams = {
+  query: {
+    type: 'DIDAuthentication';
+  };
+  interact?: {
+    service: VerifiablePresentationRequestService[];
+  };
+  challenge: string;
+  domain: string;
+};
+
+export async function performDidAuthRequest(params: DidAuthRequestParams, rawProfileRecord: ProfileRecordRaw): Promise<void> {
+  const didRecord = selectWithFactory(makeSelectDidFromProfile, { rawProfileRecord });
+  const { challenge, domain, interact } = params;
+
+  const holder = didRecord?.didDocument.authentication[0].split('#')[0] as string;
+  const key = await Ed25519VerificationKey2020.from(didRecord?.verificationKey);
+  const suite = new Ed25519Signature2020({ key });
+
+  const url = interact?.service[0]?.serviceEndpoint as string;
+  const request = await constructExchangeRequest({
+    challenge,
+    domain,
+    holder,
+    suite
+  });
+
+  const { verifiablePresentation } = await handleVcApiExchange({ url, request });
+  const credentials = extractCredentialsFrom(verifiablePresentation);
+
+  if (credentials) {
+    await store.dispatch(stageCredentials(credentials));
+  }
+}

--- a/app/lib/exchanges.ts
+++ b/app/lib/exchanges.ts
@@ -1,0 +1,67 @@
+import uuid from 'react-native-uuid';
+import vc from '@digitalcredentials/vc';
+import { Ed25519Signature2020 } from '@digitalcredentials/ed25519-signature-2020';
+import { securityLoader } from '@digitalcredentials/security-document-loader';
+import { VerifiablePresentation } from '../types/presentation';
+
+// Type definition for constructExchangeRequest function parameters
+type ConstructExchangeRequestParameters = {
+  credentials?: unknown[];
+  challenge?: string | undefined;
+  domain: string | undefined;
+  holder: string;
+  suite: Ed25519Signature2020;
+  signed?: boolean;
+};
+
+type ExchangeRequest = {
+  verifiablePresentation: VerifiablePresentation
+}
+
+type ExchangeResponse = ExchangeRequest;
+
+// Construct exchange request in the form of a verifiable presentation
+export const constructExchangeRequest = async ({
+  credentials=[],
+  challenge=uuid.v4() as string,
+  domain,
+  holder,
+  suite,
+  signed=true
+}: ConstructExchangeRequestParameters): Promise<ExchangeRequest> => {
+  const presentation = vc.createPresentation({ holder });
+  if (credentials.length !== 0) {
+    presentation.verifiableCredential = credentials;
+  }
+  let finalPresentation = presentation;
+  if (signed) {
+    const documentLoader = securityLoader().build();
+    finalPresentation = await vc.signPresentation({
+      presentation,
+      challenge,
+      domain,
+      suite,
+      documentLoader
+    });
+  }
+  return { verifiablePresentation: finalPresentation };
+};
+
+// Type definition for handleVcApiExchange function parameters
+type HandleVcApiExchangeParameters = {
+  url: string;
+  request: ExchangeRequest;
+};
+
+// Handle simplified vc api credential exchange workflow
+export const handleVcApiExchange = async ({ url, request }: HandleVcApiExchangeParameters): Promise<ExchangeResponse> => {
+  const exchangeResponseRaw = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(request, undefined, 2)
+  });
+
+  return exchangeResponseRaw.json();
+};

--- a/app/navigation/AcceptCredentialsNavigation/AcceptCredentialsNavigation.d.ts
+++ b/app/navigation/AcceptCredentialsNavigation/AcceptCredentialsNavigation.d.ts
@@ -12,7 +12,7 @@ export type AcceptCredentialsNavigationParamList = {
   ApproveCredentialScreen: {
     pendingCredentialId: string;
     profileRecordId: ObjectID;
-  }
+  };
   IssuerInfoScreen: IssuerInfoScreenParams;
 };
 

--- a/app/navigation/AppNavigation/AppNavigation.tsx
+++ b/app/navigation/AppNavigation/AppNavigation.tsx
@@ -9,7 +9,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { RootNavigation, SetupNavigation, RootNavigationParamsList } from '../';
 import { RestartScreen, LoginScreen } from '../../screens';
-import { useAppLoading, useDynamicStyles } from '../../hooks';
+import { useAppLoading, useDynamicStyles, useLCWReceiveModule } from '../../hooks';
 import { selectWalletState } from '../../store/slices/wallet';
 import { EventProvider } from 'react-native-outside-press';
 import { deepLinkConfig } from '../../lib/deepLink';
@@ -19,6 +19,7 @@ export const navigationRef = createNavigationContainerRef<RootNavigationParamsLi
 
 export default function AppNavigation(): JSX.Element | null {
   const { mixins, theme } = useDynamicStyles();
+  useLCWReceiveModule();
 
   const navigatorTheme = useMemo(() => ({
     ...DefaultTheme,

--- a/app/screens/ProfileSelectionScreen/ProfileSelectionScreen.tsx
+++ b/app/screens/ProfileSelectionScreen/ProfileSelectionScreen.tsx
@@ -8,6 +8,7 @@ import { NavHeader } from '../../components';
 import { useSelector } from 'react-redux';
 import { selectRawProfileRecords } from '../../store/slices/profile';
 import { useDynamicStyles, useSelectorFactory } from '../../hooks';
+
 import { makeSelectProfileForPendingCredentials } from '../../store/selectorFactories/makeSelectProfileForPendingCredentials';
 
 export default function ProfileSelectionScreen({ navigation, route }: ProfileSelectionScreenProps): JSX.Element {
@@ -25,10 +26,8 @@ export default function ProfileSelectionScreen({ navigation, route }: ProfileSel
 
   useEffect(() => {
     if (rawProfileRecords.length === 1) {
-      return onSelectProfile(rawProfileRecords[0]);
-    }
-
-    if (associatedProfile){
+      onSelectProfile(rawProfileRecords[0]);
+    } else if (associatedProfile){
       onSelectProfile(associatedProfile);
     }
   }, []);

--- a/app/types/digitalcredentials.d.ts
+++ b/app/types/digitalcredentials.d.ts
@@ -5,7 +5,11 @@ declare module '@digitalcredentials/vc-status-list';
 declare module '@digitalcredentials/vpqr';
 declare module '@digitalcredentials/http-client';
 declare module '@digitalcredentials/jsonld-signatures';
-declare module '@digitalcredentials/ed25519-signature-2020';
+declare module '@digitalcredentials/ed25519-signature-2020' {
+  export class Ed25519Signature2020 {
+    constructor(options?: any)
+  }
+}
 declare module '@digitalcredentials/ed25519-verification-key-2020';
 declare module 'jsonld-document-loader';
 declare module '@interop/did-web-resolver';

--- a/app/types/digitalcredentials.d.ts
+++ b/app/types/digitalcredentials.d.ts
@@ -7,7 +7,7 @@ declare module '@digitalcredentials/http-client';
 declare module '@digitalcredentials/jsonld-signatures';
 declare module '@digitalcredentials/ed25519-signature-2020' {
   export class Ed25519Signature2020 {
-    constructor(options?: any)
+    constructor(options?: unknown)
   }
 }
 declare module '@digitalcredentials/ed25519-verification-key-2020';

--- a/patches/react-native-receive-sharing-intent+2.0.0.patch
+++ b/patches/react-native-receive-sharing-intent+2.0.0.patch
@@ -1,0 +1,108 @@
+diff --git a/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java b/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
+index f752144..725918a 100644
+--- a/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
++++ b/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
+@@ -18,6 +18,7 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
+ 
+   private final ReactApplicationContext reactContext;
+   private ReceiveSharingIntentHelper receiveSharingIntentHelper;
++  private Intent oldIntent;
+ 
+   public ReceiveSharingIntentModule(ReactApplicationContext reactContext) {
+     super(reactContext);
+@@ -30,6 +31,7 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
+   protected void onNewIntent(Intent intent) {
+     Activity mActivity = getCurrentActivity();
+     if(mActivity == null) { return; }
++    oldIntent = mActivity.getIntent();
+     mActivity.setIntent(intent);
+   }
+ 
+@@ -40,7 +42,9 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
+     if(mActivity == null) { return; }
+     Intent intent = mActivity.getIntent();
+     receiveSharingIntentHelper.sendFileNames(reactContext, intent, promise);
+-    mActivity.setIntent(null);
++    if (oldIntent != null) {
++      mActivity.setIntent(oldIntent);
++    }  
+   }
+ 
+   @ReactMethod
+diff --git a/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts b/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts
+index 735c191..91dab4b 100644
+--- a/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts
++++ b/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts
+@@ -33,7 +33,7 @@ class ReceiveSharingIntentModule implements IReceiveSharingIntent {
+     }
+ 
+     clearReceivedFiles(){
+-        this.isClear = true;
++        ReceiveSharingIntent.clearFileNames();
+     }
+ 
+     
+diff --git a/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts.orig b/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts.orig
+new file mode 100644
+index 0000000..735c191
+--- /dev/null
++++ b/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts.orig
+@@ -0,0 +1,57 @@
++import type { IReceiveSharingIntent, IUtils } from "./ReceiveSharingIntent.interfaces";
++import { Platform, Linking, AppState, NativeModules } from "react-native";
++import  Utils from "./utils";
++
++const { ReceiveSharingIntent } = NativeModules;
++
++class ReceiveSharingIntentModule implements IReceiveSharingIntent {
++    private isIos: boolean = Platform.OS === "ios";
++    private utils: IUtils = new Utils();
++    private isClear: boolean = false;
++
++    getReceivedFiles(handler: Function, errorHandler: Function, protocol: string = "ShareMedia"){
++        if(this.isIos){
++            Linking.getInitialURL().then((res:any) => {
++                if (res && res.startsWith(`${protocol}://dataUrl`) && !this.isClear) {
++                    this.getFileNames(handler, errorHandler, res);
++                }
++            }).catch(() => { });
++            Linking.addEventListener("url", (res:any) => {
++                const url = res ? res.url : "";
++                if (url.startsWith(`${protocol}://dataUrl`) && !this.isClear) {
++                    this.getFileNames(handler,errorHandler, res.url);
++                }
++            });
++        }else{
++            AppState.addEventListener('change', (status: string) => {
++                if (status === 'active' && !this.isClear) {
++                    this.getFileNames(handler,errorHandler, "");
++                }
++              });
++           if(!this.isClear) this.getFileNames(handler,errorHandler, "");
++        }
++    }
++
++    clearReceivedFiles(){
++        this.isClear = true;
++    }
++
++    
++   protected getFileNames(handler: Function, errorHandler: Function, url: string){
++        if(this.isIos){
++            ReceiveSharingIntent.getFileNames(url).then((data: any)=>{         
++                 let files = this.utils.sortData(data);
++                 handler(files);
++            }).catch((e:any)=>errorHandler(e));
++        }else{
++            ReceiveSharingIntent.getFileNames().then((fileObject: any) => {
++                let files = Object.keys(fileObject).map((k) => fileObject[k])
++                handler(files);
++            }).catch((e:any)=>errorHandler(e));
++        }
++    }
++
++    
++}
++
++export default ReceiveSharingIntentModule;
+\ No newline at end of file

--- a/shim.js
+++ b/shim.js
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 if (typeof __dirname === 'undefined') global.__dirname = '/'
 if (typeof __filename === 'undefined') global.__filename = ''
 if (typeof process === 'undefined') {
@@ -37,4 +39,10 @@ function patchedBigInt(value) {
   return bi(value);
 }
 
-global.BigInt = patchedBigInt;
+if (typeof BigInt === 'undefined') {
+  if (Platform.OS === 'android') {
+    global.BigInt = patchedBigInt;
+  } else {
+    global.BigInt = bi;
+  }
+}

--- a/shim.js
+++ b/shim.js
@@ -25,11 +25,16 @@ if (typeof localStorage !== 'undefined') {
 // crypto is loaded first, so it can populate global.crypto
 // require('crypto')
 
-if (typeof BigInt === 'undefined') {
-  const BigInt = require('big-integer');
+const bi = require('big-integer');
 
-  global.BigInt = (value) => {
-    if (typeof value === 'string' && value.startsWith('0x')) return BigInt(value.slice(2), 16);
-    return BigInt(value);
+function patchedBigInt(value) {
+  if (typeof value === 'string') {
+    const match = value.match(/^0([xo])([0-9a-f]+)$/i);
+    if (match) {
+      return bi(match[2], match[1].toLowerCase() === 'x' ? 16 : 8);
+    }
   }
+  return bi(value);
 }
+
+global.BigInt = patchedBigInt;


### PR DESCRIPTION
### Overview
* Rebased version of #271
* Separated CHAPI support logic into separate lib and corresponding hook.
* Replaced `any` types with type definitions

### Notes
* Some of the changes that support this effort were made by fixing merge conflicts while rebasing. Commit a56134ef1ed599aebb6f78c77440484db5fb1a0b reflects the outlying diff post rebase.
* This does not fix the additional issues mentioned here: https://github.com/digitalcredentials/learner-credential-wallet/pull/271#issuecomment-1323999572_

In theory, #271 and #269 can be closed after this has been merged. Although I suspect additional work will be required to complete CHAPI implementation.
