### PR TITLE
Fix credential input and display (small)

### DIFF
--- a/app/lib/credentialDisplay/shared/components/IssuerInfoButton.tsx
+++ b/app/lib/credentialDisplay/shared/components/IssuerInfoButton.tsx
@@ -23,17 +23,19 @@ export default function IssuerInfoButton({ issuerId, issuerName, onPress }: Issu
 
   return (
     <TouchableOpacity onPress={_onPress} disabled={!issuerId}>
-      <View style={[styles.flexRow, styles.alignCenter]}>
+      <Text style={styles.container}>
         <Text style={styles.issuerValue}>{issuerName}</Text>
-        {issuerId && <MaterialIcons name="info-outline" size={19} color={theme.color.textPrimary} style={styles.infoIcon} />}
-      </View>
+        {' '}
+        {issuerId && <View style={styles.infoIcon}><MaterialIcons name="info-outline" size={19} color={theme.color.textPrimary} style={styles.infoIcon} /></View>}
+      </Text>
     </TouchableOpacity> 
   );
 }
 
 const dynamicStyleSheet = createDynamicStyleSheet(({ theme }) => ({
-  alignCenter: {
-    alignItems: 'center',
+  container: {
+    marginBottom: 8,
+    lineHeight: 22,
   },
   issuerValue: {
     fontFamily: theme.fontFamily.regular,
@@ -41,9 +43,7 @@ const dynamicStyleSheet = createDynamicStyleSheet(({ theme }) => ({
     color: theme.color.textPrimary,
   },
   infoIcon: {
-    marginLeft: 8,
-  },
-  flexRow: {
-    flexDirection: 'row',
+    top: 2,
+    left: 2,
   },
 }));

--- a/app/lib/credentialDisplay/shared/styles.ts
+++ b/app/lib/credentialDisplay/shared/styles.ts
@@ -32,6 +32,7 @@ export default createDynamicStyleSheet(({ theme, mixins }) => ({
     flex: 1,
   },
   spaceBetween: {
+    flex: 1,
     justifyContent: 'space-between',
   },
   flexRow: {

--- a/app/screens/AddScreen/AddScreen.tsx
+++ b/app/screens/AddScreen/AddScreen.tsx
@@ -47,6 +47,8 @@ export default function AddScreen(): JSX.Element {
   }
 
   async function addCredentialsFrom(text: string) {
+    text = text.trim();
+
     if (isDeepLink(text)) {
       const params = credentialRequestParamsFromQrText(text);
       goToCredentialFoyer(cleanCopy(params));
@@ -146,6 +148,7 @@ export default function AddScreen(): JSX.Element {
           <View style={styles.sectionContainer}>
             <View style={styles.actionInputContainer}>
               <TextInput
+                autoCapitalize="none"
                 multiline
                 value={inputValue}
                 onChangeText={setInputValue}


### PR DESCRIPTION
Closes #347

## Changes
* The input now trims the "add credential" text input
* Issuer names that span multiple lines now wrap correctly

## To Test
- [ ] **Add credential from URL with whitespace**
  1. Navigate to `Add Credential` screen
  2. Paste `https://certificates.cs50.io/85cf5a9d-bbed-40dc-b121-feec19de64b6.json` into text box
  3. Add extra whitespace/newline characters
  4. Select `Add`
 
  → _Observe credential correctly parsed from URL containing whitespace_

- [ ] **View credential card with issuer name spanning multiple lines**
  1. Select added credential from test above

  → _Observe multiline issuer name wraps correctly_