### PR TITLE
Fix Android 'add' button not clickable

### DIFF
--- a/app/screens/AddScreen/AddScreen.styles.tsx
+++ b/app/screens/AddScreen/AddScreen.styles.tsx
@@ -26,6 +26,7 @@ export default createDynamicStyleSheet(({ mixins, theme }) => ({
     flex: 1,
     height: 240,
     minHeight: 44,
+    zIndex: -1,
   },
   actionButton: {
     paddingHorizontal: 16,


### PR DESCRIPTION
Changed zIndex of Input box to -1, such that the input box is still clickable and usable but now the add button is clickable on top of it.

Resolves Issue https://github.com/digitalcredentials/learner-credential-wallet/issues/449#issue-1810747006 