### PR TITLE
fixed cancel button w/ linkedin share

### DIFF
--- a/app/styles/mixins.ts
+++ b/app/styles/mixins.ts
@@ -88,7 +88,7 @@ const mixins = (theme: ThemeType) => {
     },
     buttonContainer: {
       ...sharedMixins.shadow,
-      flex: 1,
+      flexGrow: 1,
     },
     buttonGroup: {
       flexDirection: 'row',


### PR DESCRIPTION
Project Board/Issue: https://github.com/digitalcredentials/learner-credential-wallet/issues/386

Changed from `flex` to `flexGrow` which allows cancel button and Add to LinkedIn button are in a singular line