### PR TITLE
"Create a public link" displays "GT Guide" onscreen after creating the link. (#490)

### DIFF
--- a/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
+++ b/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
@@ -10,7 +10,6 @@ import { PublicLinkScreenProps } from './PublicLinkScreen.d';
 import dynamicStyleSheet from './PublicLinkScreen.styles';
 import { LoadingIndicatorDots, NavHeader } from '../../components';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
-import credential from '../../mock/credential';
 import { createPublicLinkFor, getPublicViewLink, linkedinUrlFrom, unshareCredential } from '../../lib/publicLink';
 import { useDynamicStyles, useShareCredentials, useVerifyCredential } from '../../hooks';
 import { clearGlobalModal, displayGlobalModal } from '../../lib/globalModal';
@@ -257,7 +256,7 @@ export default function PublicLinkScreen ({ navigation, route }: PublicLinkScree
       <>
         {screenMode === PublicLinkScreenMode.Default && (
           <Text style={styles.title}>
-            {rawCredentialRecord.credential.name || 'Credential'}
+            {rawCredentialRecord?.credential?.name || 'Credential'}
           </Text>
         )}
         <Text style={styles.instructions}>{instructionsText}</Text>

--- a/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
+++ b/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
@@ -25,6 +25,8 @@ export default function PublicLinkScreen ({ navigation, route }: PublicLinkScree
 
   const share = useShareCredentials();
   const { rawCredentialRecord, screenMode = PublicLinkScreenMode.Default } = route.params;
+  const { credential } = rawCredentialRecord;
+  const { name } = credential;
   const [publicLink, setPublicLink] = useState<string | null>(null);
   const [justCreated, setJustCreated] = useState(false);
   const isVerified = useVerifyCredential(rawCredentialRecord)?.result.verified;
@@ -256,7 +258,7 @@ export default function PublicLinkScreen ({ navigation, route }: PublicLinkScree
       <>
         {screenMode === PublicLinkScreenMode.Default && (
           <Text style={styles.title}>
-            {rawCredentialRecord?.credential?.name || 'Credential'}
+            {name || 'Credential'}
           </Text>
         )}
         <Text style={styles.instructions}>{instructionsText}</Text>

--- a/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
+++ b/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
@@ -257,7 +257,7 @@ export default function PublicLinkScreen ({ navigation, route }: PublicLinkScree
       <>
         {screenMode === PublicLinkScreenMode.Default && (
           <Text style={styles.title}>
-            {credential.credentialSubject?.hasCredential?.name || 'Credential'}
+            {rawCredentialRecord.credential.name || 'Credential'}
           </Text>
         )}
         <Text style={styles.instructions}>{instructionsText}</Text>


### PR DESCRIPTION
Resolves [Issue 490](https://github.com/digitalcredentials/learner-credential-wallet/issues/490)

"GT Guide" has been replaced with the actual credential name.