### PR TITLE
Bold Learner Credential Wallet text on about screen #325

### DIFF
--- a/app/navigation/SettingsNavigation/SettingsNavigation.styles.tsx
+++ b/app/navigation/SettingsNavigation/SettingsNavigation.styles.tsx
@@ -61,6 +61,12 @@ export default createDynamicStyleSheet(({ theme, mixins }) => ({
   },
   paragraphCenter: {
     ...mixins.paragraphText,
+    fontSize: theme.fontSize.medium,
+    textAlign: 'center',
+    marginTop: 30,
+  },
+  aboutTitleBolded: {
+    ...mixins.paragraphText,
     fontFamily: theme.fontFamily.bold,
     fontSize: theme.fontSize.medium,
     textAlign: 'center',

--- a/app/navigation/SettingsNavigation/SettingsNavigation.tsx
+++ b/app/navigation/SettingsNavigation/SettingsNavigation.tsx
@@ -159,7 +159,7 @@ function About({ navigation }: AboutProps): JSX.Element {
           accessible
           accessibilityLabel={`${appConfig.displayName} Logo`}
         />
-        <Text style={styles.paragraphCenter}>{appConfig.displayName}</Text>
+        <Text style={styles.aboutTitleBolded}>{appConfig.displayName}</Text>
         <Text style={styles.paragraphCenter}>
           This mobile wallet was developed by the Digital Credentials Consortium, a network of leading international universities designing an open infrastructure for academic credentials.
         </Text>


### PR DESCRIPTION
Now, only the title is bolded on the about page

Resolves [Issue #325](https://github.com/digitalcredentials/learner-credential-wallet/issues/325)