### PR TITLE
Extract app name to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ These values can be overridden, but development values should not be committed t
 └── ios ← Same as android, except it also uses Cocoapods for dependency management
 ```
 
+#### Configuration
+
+Overridable configuration lives in two places:
+
+1. [`app.json`](./app.json) - created by Expo, contains app name, icon, splash
+   page color, etc.
+2. [`app/config/index.ts`](./app/config/index.ts) - contains everything else,
+   including a list of Known DID Registries, deep link schemes, app website URLs,
+   and so on.
+
 ### Adding new credential display
 
 A custom display can be created for different credentials, to do so:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following build commands failed:
 Then check your version of cocoa pods.  If it is 1.9.3, try upgrading it to 
 something newer, like 1.11.2_1
 
-See [Installing LCW on Linux](install-linux.md) on setting up the project on Linux.
+See [Installing on Linux](install-linux.md) on setting up the project on Linux.
 
 ### Environment
 

--- a/android/app/src/main/java/app/lcw/MainApplication.java
+++ b/android/app/src/main/java/app/lcw/MainApplication.java
@@ -43,7 +43,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       List<ReactPackage> packages = new PackageList(this).getPackages();
       packages.add(new ModuleRegistryAdapter(mModuleRegistryProvider));
-      packages.add(new LCWReceivePackage());
+      packages.add(new WalletReceivePackage());
       return packages;
     }
 

--- a/android/app/src/main/java/app/lcw/WalletEventReceiveModule.java
+++ b/android/app/src/main/java/app/lcw/WalletEventReceiveModule.java
@@ -20,7 +20,7 @@ import javax.json.JsonException;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 
-public class LCWReceiveModule extends ReactContextBaseJavaModule {
+public class WalletEventReceiveModule extends ReactContextBaseJavaModule {
   // Events
   private final String CredentialReceivedEventKey = "CREDENTIAL_RECEIVED_EVENT";
   private final String CredentialReceivedEventValue = "credential_received";
@@ -36,14 +36,14 @@ public class LCWReceiveModule extends ReactContextBaseJavaModule {
   // React
   private final ReactApplicationContext reactContext;
 
-  LCWReceiveModule(ReactApplicationContext context) {
+  WalletEventReceiveModule(ReactApplicationContext context) {
     super(context);
     this.reactContext = context;
   }
 
   @Override
   public String getName() {
-    return "LCWReceiveModule";
+    return "WalletEventReceiveModule";
   }
 
   @Override
@@ -87,7 +87,7 @@ public class LCWReceiveModule extends ReactContextBaseJavaModule {
             .emit(DidAuthReceivedEventValue, payload);
       }
     } catch (JsonException | IllegalStateException | ClassCastException e) {
-      Log.e("LCWReceiveModule.processData.error", e.getMessage());
+      Log.e("WalletEventReceiveModule.processData.error", e.getMessage());
       return;
     }
   }
@@ -121,7 +121,7 @@ public class LCWReceiveModule extends ReactContextBaseJavaModule {
       intent.setAction(null)
                .setType(null);
     } catch (IOException e) {
-      Log.e("LCWReceiveModule.getData.error", e.getMessage());
+      Log.e("WalletEventReceiveModule.getData.error", e.getMessage());
       return;
     }
   }

--- a/android/app/src/main/java/app/lcw/WalletReceivePackage.java
+++ b/android/app/src/main/java/app/lcw/WalletReceivePackage.java
@@ -18,7 +18,7 @@ public class WalletReceivePackage implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     List<NativeModule> modules = new ArrayList<>();
-    modules.add(new WalletReceiveModule(reactContext));
+    modules.add(new WalletEventReceiveModule(reactContext));
     return modules;
   }
 }

--- a/android/app/src/main/java/app/lcw/WalletReceivePackage.java
+++ b/android/app/src/main/java/app/lcw/WalletReceivePackage.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class LCWReceivePackage implements ReactPackage {
+public class WalletReceivePackage implements ReactPackage {
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
     return Collections.emptyList();
@@ -18,7 +18,7 @@ public class LCWReceivePackage implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     List<NativeModule> modules = new ArrayList<>();
-    modules.add(new LCWReceiveModule(reactContext));
+    modules.add(new WalletReceiveModule(reactContext));
     return modules;
   }
 }

--- a/app/config/index.ts
+++ b/app/config/index.ts
@@ -17,9 +17,16 @@ export const KnownDidRegistries = [
   }
 ];
 
-export const DeepLinkConfig = {
+export const LinkConfig = {
   schemes: {
     customProtocol: ['dccrequest://', 'org.dcconsortium://'],
     universalAppLink: 'https://lcw.app/mobile'
+  },
+  registerWalletUrl: 'https://lcw.app/register-wallet.html',
+  appWebsite: {
+    home: 'https://lcw.app',
+    // FAQ page assumes #public-link,
+    //   #public-link-unshare, and #add-to-linkedin sections
+    faq: 'https://lcw.app/faq.html'
   }
 };

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -10,5 +10,5 @@ export * from './useSelectorFactory';
 export * from './useAppDispatch';
 export * from './useThemeContext';
 export * from './useDynamicStyles';
-export * from './useLCWReceiveModule';
+export * from './useWalletReceiveModule';
 export * from './useSelectedExchangeCredentials';

--- a/app/hooks/useWalletReceiveModule.tsx
+++ b/app/hooks/useWalletReceiveModule.tsx
@@ -8,36 +8,36 @@ import { navigationRef } from '../navigation';
 import { stageCredentials } from '../store/slices/credentialFoyer';
 import { useAppDispatch, useDynamicStyles } from '.';
 
-type LCWReceiveModule = NativeModule & {
-  getConstants: () => LCWReceiveModuleConstants;
+type WalletReceiveModule = NativeModule & {
+  getConstants: () => WalletReceiveModuleConstants;
   getData: () => void;
 }
 
-type LCWReceiveModuleConstants = {
+type WalletReceiveModuleConstants = {
   CREDENTIAL_RECEIVED_EVENT: string;
   DID_AUTH_RECEIVED_EVENT: string;
   CREDENTIAL: string;
   DID_AUTH: string;
 }
 
-type LCWReceiveModuleEvent = Record<string, string>;
+type ReceiveModuleEventType = Record<string, string>;
 
-let LCWReceiveModule: LCWReceiveModule;
+let WalletReceiveModule: WalletReceiveModule;
 let CREDENTIAL_RECEIVED_EVENT: string;
 let DID_AUTH_RECEIVED_EVENT: string;
 let CREDENTIAL: string;
 let DID_AUTH: string;
 
 if (Platform.OS === 'android') {
-  LCWReceiveModule = NativeModules.LCWReceiveModule;
-  const constants = LCWReceiveModule.getConstants();
+  WalletReceiveModule = NativeModules.WalletReceiveModule;
+  const constants = WalletReceiveModule.getConstants();
   CREDENTIAL_RECEIVED_EVENT = constants.CREDENTIAL_RECEIVED_EVENT;
   DID_AUTH_RECEIVED_EVENT = constants.DID_AUTH_RECEIVED_EVENT;
   CREDENTIAL = constants.CREDENTIAL;
   DID_AUTH = constants.DID_AUTH;
 }
 
-export function useLCWReceiveModule(): void {
+export function useWalletReceiveModule(): void {
   const dispatch = useAppDispatch();
   const { mixins } = useDynamicStyles();
 
@@ -55,7 +55,7 @@ export function useLCWReceiveModule(): void {
     )
   };
 
-  const onCredentialReceived = async (event: LCWReceiveModuleEvent) => {
+  const onCredentialReceived = async (event: ReceiveModuleEventType) => {
     displayGlobalModal(dataLoadingModalState);
     const credentialString = event[CREDENTIAL];
     const credential = JSON.parse(credentialString);
@@ -65,7 +65,7 @@ export function useLCWReceiveModule(): void {
     const rawProfileRecord = await NavigationUtil.selectProfile();
 
     if (navigationRef.isReady()) {
-      navigationRef.navigate('AcceptCredentialsNavigation', { 
+      navigationRef.navigate('AcceptCredentialsNavigation', {
         screen: 'ApproveCredentialsScreen',
         params: {
           rawProfileRecord
@@ -74,7 +74,7 @@ export function useLCWReceiveModule(): void {
     }
   };
 
-  const onDidAuthReceived = async (event: LCWReceiveModuleEvent) => {
+  const onDidAuthReceived = async (event: ReceiveModuleEventType) => {
     displayGlobalModal(dataLoadingModalState);
     const didAuthString = event[DID_AUTH];
     const didAuthRequest = JSON.parse(didAuthString);
@@ -86,7 +86,7 @@ export function useLCWReceiveModule(): void {
 
       navigationRef.navigate('AcceptCredentialsNavigation', {
         screen: 'ApproveCredentialsScreen',
-        params: {  
+        params: {
           rawProfileRecord
         }
       });
@@ -95,7 +95,7 @@ export function useLCWReceiveModule(): void {
 
   useEffect(() => {
     if (Platform.OS === 'android') {
-      const eventEmitter = new NativeEventEmitter(LCWReceiveModule);
+      const eventEmitter = new NativeEventEmitter(WalletReceiveModule);
       const credentialSubscription = eventEmitter.addListener(
         CREDENTIAL_RECEIVED_EVENT,
         onCredentialReceived
@@ -104,12 +104,12 @@ export function useLCWReceiveModule(): void {
         DID_AUTH_RECEIVED_EVENT,
         onDidAuthReceived
       );
-    
+
       const appStateSubscription = AppState.addEventListener(
         'change',
         (state) => {
           if (state === 'active') {
-            LCWReceiveModule.getData();
+            WalletReceiveModule.getData();
           }
         }
       );

--- a/app/lib/deepLink.ts
+++ b/app/lib/deepLink.ts
@@ -7,15 +7,15 @@ import { ChapiCredentialRequest } from '../types/chapi';
 import { credentialRequestFromChapiUrl } from './decode';
 import { encodeQueryParams } from './encode';
 import { onShareIntent } from './shareIntent';
-import { DeepLinkConfig } from '../config';
+import { LinkConfig } from '../config';
 
 /**
  * In order to support OAuth redirects, the Android intent filter was set
  * specific to the scheme `dccrequest` and path `request`. If new paths are
  * added here, they must also be added to `android/app/src/main/AndroidManifest.xml`.
  */
-const DEEP_LINK_SCHEMES = DeepLinkConfig.schemes.customProtocol
-  .concat(DeepLinkConfig.schemes.universalAppLink);
+const DEEP_LINK_SCHEMES = LinkConfig.schemes.customProtocol
+  .concat(LinkConfig.schemes.universalAppLink);
 const DEEP_LINK_PATHS: DeepLinkPaths = {
   request: (credentialRequestParams) => deepLinkNavigate('ProfileSelectionScreen', {
     onSelectProfile: (rawProfileRecord) => navigationRef.navigate('AcceptCredentialsNavigation', {

--- a/app/lib/registerWallet.ts
+++ b/app/lib/registerWallet.ts
@@ -1,9 +1,10 @@
-import {Linking} from 'react-native';
+import { Linking } from 'react-native';
+import { LinkConfig } from '../config';
 
 export function registerWallet(): void {
-  Linking.canOpenURL('https://lcw.app/register-wallet.html').then(supported => {
+  Linking.canOpenURL(LinkConfig.registerWalletUrl).then(supported => {
     if (supported) {
-      Linking.openURL('https://lcw.app/register-wallet.html');
+      Linking.openURL(LinkConfig.registerWalletUrl);
     } else {
       console.log('Unable to register wallet! Failed URL');
     }

--- a/app/navigation/AppNavigation/AppNavigation.tsx
+++ b/app/navigation/AppNavigation/AppNavigation.tsx
@@ -10,7 +10,7 @@ import { ReactHooksWrapper, setHook } from 'react-hooks-outside';
 
 import { RootNavigation, SetupNavigation, RootNavigationParamsList } from '../';
 import { RestartScreen, LoginScreen } from '../../screens';
-import { useAppLoading, useDynamicStyles, useLCWReceiveModule, useSelectedExchangeCredentials } from '../../hooks';
+import { useAppLoading, useDynamicStyles, useWalletReceiveModule, useSelectedExchangeCredentials } from '../../hooks';
 import { selectWalletState } from '../../store/slices/wallet';
 import { EventProvider } from 'react-native-outside-press';
 import { deepLinkConfig } from '../../lib/deepLink';
@@ -23,7 +23,7 @@ setHook('selectedExchangeCredentials', useSelectedExchangeCredentials);
 
 export default function AppNavigation(): JSX.Element | null {
   const { mixins, theme } = useDynamicStyles();
-  useLCWReceiveModule();
+  useWalletReceiveModule();
 
   const navigatorTheme = useMemo(() => ({
     ...DefaultTheme,

--- a/app/navigation/SettingsNavigation/SettingsNavigation.tsx
+++ b/app/navigation/SettingsNavigation/SettingsNavigation.tsx
@@ -6,6 +6,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import DeviceInfo from 'react-native-device-info';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
+import { LinkConfig } from '../../config';
 import appConfig from '../../../app.json';
 import walletImage from '../../assets/wallet.png';
 import dynamicStyleSheet from './SettingsNavigation.styles';
@@ -166,9 +167,9 @@ function About({ navigation }: AboutProps): JSX.Element {
           More information at&nbsp;
           <Text
             style={styles.link}
-            onPress={() => Linking.openURL('https://lcw.app')}
+            onPress={() => Linking.openURL(LinkConfig.appWebsite.home)}
           >
-            https://lcw.app
+            {LinkConfig.appWebsite.home}
           </Text>.
         </Text>
         <Text style={styles.paragraphCenter}>

--- a/app/screens/DeveloperScreen/DeveloperScreen.tsx
+++ b/app/screens/DeveloperScreen/DeveloperScreen.tsx
@@ -30,7 +30,7 @@ export default function DeveloperScreen({ navigation }: DeveloperScreenProps): J
   async function goToApproveCredentials() {
     if (navigationRef.isReady()) {
       const rawProfileRecord = await NavigationUtil.selectProfile();
-      navigationRef.navigate('AcceptCredentialsNavigation', { 
+      navigationRef.navigate('AcceptCredentialsNavigation', {
         screen: 'ApproveCredentialsScreen',
         params: {
           rawProfileRecord,
@@ -62,7 +62,7 @@ export default function DeveloperScreen({ navigation }: DeveloperScreenProps): J
 
     async function onPressShare() {
       const date = new Date().valueOf();
-      const fileName = `lcw-${date}.log`;
+      const fileName = `wallet-${date}.log`;
 
       await shareData(fileName, logData);
     }

--- a/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
+++ b/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
@@ -7,6 +7,7 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import OutsidePressHandler from 'react-native-outside-press';
 import Share from 'react-native-share';
 
+import { LinkConfig } from '../../config';
 import { PublicLinkScreenProps } from './PublicLinkScreen.d';
 import dynamicStyleSheet from './PublicLinkScreen.styles';
 import { LoadingIndicatorDots, NavHeader } from '../../components';
@@ -152,7 +153,7 @@ export default function PublicLinkScreen ({ navigation, route }: PublicLinkScree
             titleStyle={[mixins.buttonClearTitle, mixins.modalLinkText]}
             containerStyle={mixins.buttonClearContainer}
             title="What does this mean?"
-            onPress={() => Linking.openURL('https://lcw.app/faq.html#public-link')}
+            onPress={() => Linking.openURL(`${LinkConfig.appWebsite.faq}#public-link`)}
           />
         </>
       )
@@ -174,7 +175,7 @@ export default function PublicLinkScreen ({ navigation, route }: PublicLinkScree
             titleStyle={[mixins.buttonClearTitle, mixins.modalLinkText]}
             containerStyle={mixins.buttonClearContainer}
             title="What does this mean?"
-            onPress={() => Linking.openURL('https://lcw.app/faq.html#public-link-unshare')}
+            onPress={() => Linking.openURL(`${LinkConfig.appWebsite.faq}#public-link-unshare`)}
           />
         </>
       )
@@ -242,7 +243,7 @@ export default function PublicLinkScreen ({ navigation, route }: PublicLinkScree
             titleStyle={[mixins.buttonClearTitle, mixins.modalLinkText]}
             containerStyle={mixins.buttonClearContainer}
             title="What does this mean?"
-            onPress={() => Linking.openURL('https://lcw.app/faq.html#add-to-linkedin')}
+            onPress={() => Linking.openURL(`${LinkConfig.appWebsite.faq}#add-to-linkedin`)}
           />
         </>
       )

--- a/app/screens/ShareHomeScreen/ShareHomeScreen.tsx
+++ b/app/screens/ShareHomeScreen/ShareHomeScreen.tsx
@@ -16,6 +16,7 @@ import { displayGlobalModal } from '../../lib/globalModal';
 import { hasPublicLink } from '../../lib/publicLink';
 import { verificationResultFor } from '../../lib/verifiableObject';
 import { DidRegistryContext } from '../../init/registries';
+import { LinkConfig } from '../../config';
 
 export default function ShareHomeScreen({ navigation, route }: ShareHomeScreenProps): JSX.Element {
   const { styles, theme, mixins } = useDynamicStyles(dynamicStyleSheet);
@@ -157,7 +158,7 @@ export default function ShareHomeScreen({ navigation, route }: ShareHomeScreenPr
               titleStyle={[mixins.buttonClearTitle, mixins.modalLinkText]}
               containerStyle={mixins.buttonClearContainer}
               title="What does this mean?"
-              onPress={() => Linking.openURL('https://lcw.app/faq.html#public-link')}
+              onPress={() => Linking.openURL(`${LinkConfig.appWebsite.faq}#public-link`)}
             />
           </>
         ),

--- a/app/screens/VerificationStatusScreen/VerificationStatusScreen.tsx
+++ b/app/screens/VerificationStatusScreen/VerificationStatusScreen.tsx
@@ -24,9 +24,9 @@ export default function VerificationStatusScreen({
         <VerificationCard verifyPayload={verifyPayload} showDetails/>
         <VerificationStatusCard credential={credential} verifyPayload={verifyPayload} />
         <Text style={styles.footerText}>
-         The Learner Credential Wallet will periodically check the verification status of 
-         your credential. Please make sure you’ve connected to a network recently to 
-         ensure your credential can be verified. If you’re still having problems, 
+         The Wallet will periodically check the verification status of
+         your credential. Please make sure you’ve connected to a network recently to
+         ensure your credential can be verified. If you’re still having problems,
          please contact your issuing organization.
         </Text>
       </ScrollView>


### PR DESCRIPTION
In preparation for OWF / to make re-branding easier, this PR extracts hardcoded instances of the LCW name and web site into config.

Also, adds a small section in the README on where the config files live.