### PR TITLE
Expo config updates for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,5 @@ ios_old
 
 # generate the native folders by expo prebuild command
 ios
+*.xcarchive
 android

--- a/app.json
+++ b/app.json
@@ -1,10 +1,10 @@
 {
   "displayName": "Learner Credential Wallet",
   "expo": {
-    "runtimeVersion": "1.0.0",
+    "runtimeVersion": "2.1.0",
+    "version": "2.1.0",
     "name": "Learner Credential Wallet",
     "slug": "learner-credential-wallet",
-    "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./app/assets/icon.png",
     "backgroundColor": "#1F2937",
@@ -20,6 +20,7 @@
       "**/*"
     ],
     "ios": {
+      "buildNumber": "80",
       "supportsTablet": true,
       "bundleIdentifier": "edu.mit.eduwallet",
       "entitlements": {

--- a/app.json
+++ b/app.json
@@ -38,6 +38,7 @@
       }
     },
     "android": {
+      "versionCode": 80,
       "adaptiveIcon": {
         "foregroundImage": "./app/assets/adaptive-icon.png",
         "backgroundColor": "#1F2937"
@@ -59,7 +60,7 @@
           "category": ["BROWSABLE", "DEFAULT"]
         }
       ],
-      "package": "edu.wallet"
+      "package": "app.lcw"
     },
     "web": {
       "favicon": "./app/assets/favicon.png"

--- a/app/navigation/ExchangeCredentialsNavigation/ExchangeCredentialsNavigation.d.ts
+++ b/app/navigation/ExchangeCredentialsNavigation/ExchangeCredentialsNavigation.d.ts
@@ -1,5 +1,5 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import { ChapiCredentialRequest } from '../../lib/chapi';
+import { ChapiCredentialRequest } from '../../types/chapi';
 
 export type ExchangeCredentialsNavigationParamList = {
   ExchangeCredentials: { request: ChapiCredentialRequest; };

--- a/disableAndroidFlipper.sh
+++ b/disableAndroidFlipper.sh
@@ -1,6 +1,0 @@
-set -x -e
-# comments out flipper support for Android because it clashes with quick-crypto
-sed -i.bak '/implementation("com.facebook.react:flipper-integration")/s/^/\/\/ /' ./android/app/build.gradle
-
-sed -i.bak '/ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)/s/^/\/\/ /' ./android/app/src/main/java/edu/wallet/MainApplication.kt
-sed -i.bak '/import com.facebook.react.flipper.ReactNativeFlipper/s/^/\/\/ /' ./android/app/src/main/java/edu/wallet/MainApplication.kt

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "npx patch-package",
     "fix-deps": "npx expo install --check",
     "prebuild:ios": "EXPO_NO_TELEMETRY=1 EXPO_NO_GIT_STATUS=1 npx expo prebuild --clean -p ios",
-    "prebuild:android": "EXPO_NO_TELEMETRY=1 EXPO_NO_GIT_STATUS=1 npx expo prebuild --clean -p android && ./disableAndroidFlipper.sh"
+    "prebuild:android": "EXPO_NO_TELEMETRY=1 EXPO_NO_GIT_STATUS=1 npx expo prebuild --clean -p android"
   },
   "expo": {
     "autolinking": {


### PR DESCRIPTION
* Fix Expo config file to enable publishing to iOS and Google App Store
* Fix CHAPI import statement
* Drop unused `disableFlipper` script.

Addresses issue #606 