### PR TITLE
Animated: 'use Native Driver' was not specified 716

### DIFF
--- a/app/components/CredentialRequestHandler/CredentialRequestHandler.tsx
+++ b/app/components/CredentialRequestHandler/CredentialRequestHandler.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useAsyncCallback } from 'react-async-hook';
 import { Text, View } from 'react-native';
-import AnimatedEllipsis from 'react-native-animated-ellipsis';
+import AnimatedEllipsis from 'rn-animated-ellipsis';
 
 import ConfirmModal from '../ConfirmModal/ConfirmModal';
 import { useAppDispatch, useDynamicStyles } from '../../hooks';
@@ -62,7 +62,7 @@ export default function CredentialRequestHandler({
     >
       {credentialRequest.loading ? (
         <View style={styles.loadingContainer}>
-          <AnimatedEllipsis style={styles.loadingDots} minOpacity={0.4} animationDelay={200}/>
+          <AnimatedEllipsis style={styles.loadingDots} minOpacity={0.4} animationDelay={200} useNativeDriver={true} />
         </View>
       ) : (
         <Text style={styles.modalText}>{errorMessage}</Text>

--- a/app/components/LoadingIndicatorDots/LoadingIndicatorDots.tsx
+++ b/app/components/LoadingIndicatorDots/LoadingIndicatorDots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
-import AnimatedEllipsis from 'react-native-animated-ellipsis';
+import AnimatedEllipsis from 'rn-animated-ellipsis';
 import { useDynamicStyles } from '../../hooks';
 
 import dynamicStyleSheet from './LoadingIndicatorDots.styles';
@@ -10,7 +10,7 @@ export default function LoadingIndicatorDots(): React.ReactElement {
 
   return (
     <View style={styles.loadingContainer}>
-      <AnimatedEllipsis style={styles.loadingDots} minOpacity={0.4} animationDelay={200}/>
+      <AnimatedEllipsis style={styles.loadingDots} minOpacity={0.4} animationDelay={200} useNativeDriver={true}/>
     </View>
   );
 }

--- a/app/types/declarations.d.ts
+++ b/app/types/declarations.d.ts
@@ -17,7 +17,7 @@ declare module '@digitalcredentials/lru-memoize';
 declare module 'jsonld-document-loader';
 declare module '@interop/did-web-resolver';
 declare module 'json-canonicalize';
-declare module 'react-native-animated-ellipsis';
+declare module 'rn-animated-ellipsis';
 declare module 'react-native-html-to-pdf';
 declare module 'react-native-keychain';
 declare module 'react-native-receive-sharing-intent';

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@craftzdog/react-native-buffer": "^6.0.5",
-    "@digitalcredentials/data-integrity": "^2.5.1-beta.1", 
+    "@digitalcredentials/data-integrity": "^2.5.1-beta.1",
     "@digitalcredentials/did-method-key": "^2.0.3",
     "@digitalcredentials/ed25519-signature-2020": "^6.0.0",
     "@digitalcredentials/ed25519-verification-key-2020": "^4.0.0",
@@ -74,7 +74,6 @@
     "react-async-hook": "^4.0.0",
     "react-hooks-outside": "^1.0.3",
     "react-native": "0.73.4",
-    "react-native-animated-ellipsis": "^2.0.0",
     "react-native-circular-progress": "^1.3.7",
     "react-native-device-info": "^10.12.0",
     "react-native-document-picker": "^8.2.2",
@@ -104,6 +103,7 @@
     "react-native-vision-camera": "^3.8.2",
     "react-redux": "^7.2.4",
     "realm": "^11.10.2",
+    "rn-animated-ellipsis": "^2.1.3",
     "text-encoding": "^0.7.0",
     "util": "^0.10.4",
     "validator": "^13.11.0"


### PR DESCRIPTION
Signed-off-by: Santhosh Vijay <santosh.v@oneorigin.us>

Added package react-native package with latest version 2.1.3  https://www.npmjs.com/package/rn-animated-ellipsis/v/2.1.3 which handles useNativeDriver as a prop and removed react-native-animated-ellipsis.