### PR TITLE
Add failing verifier-core unit test.

### DIFF
--- a/app/types/presentation.ts
+++ b/app/types/presentation.ts
@@ -2,10 +2,10 @@ import type { Credential, Proof, Issuer } from './credential';
 
 export type VerifiablePresentation = {
   readonly '@context': string[];
-  readonly issuer: Issuer;
+  readonly issuer?: Issuer;
   readonly type: string;
   readonly verifiableCredential: Credential | Credential[];
-  readonly proof: Proof;
+  readonly proof?: Proof;
 }
 
 export enum PresentationError {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,7 +7,9 @@ const packagesToTransformWithBabel = [
   'expo-modules-core',
   'expo-font',
   'react-native-fs',
-  '@digitalcredentials/http-client',
+  'base58-universal',
+  'base64url-universal',
+  '@digitalcredentials/*',
   'realm',
   '@realm', // <-- critical for @realm/fetch
   'react-redux',

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@digitalcredentials/vc": "^9.0.0",
     "@digitalcredentials/vc-bitstring-status-list": "^1.0.0",
     "@digitalcredentials/vc-status-list": "^9.0.0",
-    "@digitalcredentials/verifier-core": "^1.0.0-beta.6",
+    "@digitalcredentials/verifier-core": "^1.0.0-beta.8",
     "@digitalcredentials/vpqr": "^2.2.1",
     "@expo-google-fonts/roboto-mono": "^0.2.2",
     "@expo-google-fonts/rubik": "^0.2.0",

--- a/test/verifier-core.test.ts
+++ b/test/verifier-core.test.ts
@@ -1,0 +1,16 @@
+import { verifyPresentation } from '../app/lib/validate';
+
+import { mockCredential } from '../app/mock/credential';
+import { VerifiablePresentation } from '../app/types/presentation';
+
+describe.only('verifier-core usage', () => {
+  it('should verify a VP', async () => {
+    const mockVp: VerifiablePresentation = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: 'VerifiablePresentation',
+      verifiableCredential: [ mockCredential ]
+    }
+    const result = await verifyPresentation(mockVp);
+    console.log(result);
+  })
+})

--- a/test/verifier-core.test.ts
+++ b/test/verifier-core.test.ts
@@ -3,7 +3,7 @@ import { verifyPresentation } from '../app/lib/validate';
 import { mockCredential } from '../app/mock/credential';
 import { VerifiablePresentation } from '../app/types/presentation';
 
-describe.only('verifier-core usage', () => {
+describe('verifier-core usage', () => {
   it('should verify a VP', async () => {
     const mockVp: VerifiablePresentation = {
       '@context': ['https://www.w3.org/2018/credentials/v1'],


### PR DESCRIPTION
Addresses https://github.com/openwallet-foundation-labs/learner-credential-wallet/issues/821

Add a (currently) failing unit test of `verifier-core` related code, to test Jest compatibility.
Opened upstream issue https://github.com/digitalcredentials/verifier-core/issues/16