### PR TITLE
Remove Accept All Button When Only One Credential in Available Creden…

### DIFF
--- a/app/screens/ApproveCredentialsScreen/ApproveCredentialsScreen.tsx
+++ b/app/screens/ApproveCredentialsScreen/ApproveCredentialsScreen.tsx
@@ -28,7 +28,7 @@ export default function ApproveCredentialsScreen({ navigation, route }: ApproveC
   );
 
   const [modalIsOpen, setModalIsOpen] = useState(false);
-  const showAcceptAllButton = pendingCredentials.length > 0;
+  const showAcceptAllButton = pendingCredentials.length > 1;
 
   async function goToHome() {
     await dispatch(clearFoyer());


### PR DESCRIPTION
PR created for #738 
Update condition for displaying the "Accept All" button in ApproveCredentialsScreen only if more than one credential present