### PR TITLE
show restore wallet details list

### DIFF
--- a/app/types/profile.ts
+++ b/app/types/profile.ts
@@ -4,6 +4,7 @@ export type ProfileImportReport = {
   userIdImported: boolean;
   profileDuplicate?: boolean;
   credentials: CredentialImportReport;
+  profileName?: string;
 };
 
 export type ProfileMetadata = {


### PR DESCRIPTION
Created PR for #852 

Implemented the missing functionality to show lists for duplicate profiles ignored, profiles successfully imported, and items successfully imported in the restored wallet details

In the details screen Users will now see:
**"X profiles successfully imported"** with a list of actual profile names
**"X duplicate profiles skipped"** with a list of profile names that were duplicates
**"X items successfully imported"** with a list of credential names 
**"X duplicate items skipped"** with a list of credential names 
**"X profiles failed to import"** with a list of profile names that failed