### PR TITLE
Credential Details Page – Options menu becomes transparent on click

### DIFF
--- a/app/components/MenuItem/MenuItem.tsx
+++ b/app/components/MenuItem/MenuItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, View, Text } from 'react-native';
+import { TouchableHighlight, View, Text } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import dynamicStyleSheet from './MenuItem.styles';
@@ -10,23 +10,23 @@ export default function MenuItem({ icon, title, onPress }: MenuItemProps): React
   const { styles, theme } = useDynamicStyles(dynamicStyleSheet);
 
   return (
-    <TouchableOpacity
-      style={[
-        styles.menuItemContainer,
-        { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 12, minHeight: 60 }
-      ]}
+    <TouchableHighlight
+      style={styles.menuItemContainer}
+      underlayColor={theme.color.backgroundSecondary}
       onPress={onPress}
     >
-      { icon && (
-        <MaterialIcons
-          name={icon}
-          size={theme.iconSize}
-          color={theme.color.iconInactive}
-        />
-      )}
-      <View style={{ flex: 1, marginLeft: icon ? 12 : 0 }}>
-        <Text style={styles.menuItemTitle}>{title}</Text>
+      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        { icon && (
+          <MaterialIcons
+            name={icon}
+            size={theme.iconSize}
+            color={theme.color.iconInactive}
+          />
+        )}
+        <View style={{ flex: 1, marginLeft: icon ? 12 : 0 }}>
+          <Text style={styles.menuItemTitle}>{title}</Text>
+        </View>
       </View>
-    </TouchableOpacity>
+    </TouchableHighlight>
   );
 }


### PR DESCRIPTION
Created PR for #875 
Menu options maintain consistent visibility and contrast when tapped or clicked

***Screenshot***
Before:
<img width="544" height="1030" alt="Screenshot 2025-10-14 at 10 11 13 PM" src="https://github.com/user-attachments/assets/847651db-7ca2-42e8-b61e-00b7a7028949" />

After:
<img width="538" height="1015" alt="Screenshot 2025-10-14 at 3 22 10 PM" src="https://github.com/user-attachments/assets/025f462b-3b5b-4d4c-a446-768434869158" />
