### PR TITLE
900: Cannot go back from credential preview from managed profiles

### DIFF
--- a/app/components/CredentialListItem/CredentialListItem.tsx
+++ b/app/components/CredentialListItem/CredentialListItem.tsx
@@ -20,7 +20,7 @@ export default function CredentialListItem({ item, onShare, onDelete }: Props) {
   const onSelect = () => {
     if (navigationRef.isReady()) {
       navigationRef.navigate('HomeNavigation', {
-        screen: 'CredentialNavigation',
+        screen: 'SettingsNavigation',
         params: {
           screen: 'CredentialScreen',
           params: { rawCredentialRecord: item }

--- a/app/navigation/SettingsNavigation/SettingsNavigation.d.ts
+++ b/app/navigation/SettingsNavigation/SettingsNavigation.d.ts
@@ -1,7 +1,8 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import { ReactNode } from 'react';
-import { DetailsScreenParams } from '../../screens';
+import { DetailsScreenParams, PublicLinkScreenParams } from '../../screens';
 import { ProfileCredentialScreenParams } from '../../screens/ProfileCredentialScreen/ProfileCredentialScreen.d';
+import { CredentialRecordRaw } from '../../types/credential';
 
 export type SettingsItemProps = {
   readonly title: string;
@@ -17,6 +18,11 @@ export type SettingsNavigationParamList = {
   ManageProfilesScreen: undefined;
   AddExistingProfileScreen: undefined;
   ProfileCredentialScreen: ProfileCredentialScreenParams;
+  CredentialScreen: {
+    rawCredentialRecord: CredentialRecordRaw;
+    noShishKabob?: boolean;
+  };
+  PublicLinkScreen: PublicLinkScreenParams;
   DetailsScreen: DetailsScreenParams;
   DeveloperScreen: undefined;
   WASScreen: undefined;
@@ -28,5 +34,7 @@ export type RestoreWalletScreenProps = StackScreenProps<SettingsNavigationParamL
 export type AboutProps = StackScreenProps<SettingsNavigationParamList, 'About'>;
 export type ManageProfilesScreenProps = StackScreenProps<SettingsNavigationParamList, 'ManageProfilesScreen'>;
 export type AddExistingProfileScreenProps = StackScreenProps<SettingsNavigationParamList, 'AddExistingProfileScreen'>;
+export type CredentialScreenSettingsProps = StackScreenProps<SettingsNavigationParamList, 'CredentialScreen'>;
+export type PublicLinkScreenSettingsProps = StackScreenProps<SettingsNavigationParamList, 'PublicLinkScreen'>;
 export type DetailsScreenSettingsProps = StackScreenProps<SettingsNavigationParamList, 'DetailsScreen'>;
 export type DeveloperScreenProps = StackScreenProps<SettingsNavigationParamList, 'DeveloperScreen'>;

--- a/app/navigation/SettingsNavigation/SettingsNavigation.tsx
+++ b/app/navigation/SettingsNavigation/SettingsNavigation.tsx
@@ -17,7 +17,7 @@ import {
   AboutProps,
   SettingsNavigationParamList,
 } from './SettingsNavigation.d';
-import { AddExistingProfileScreen, DetailsScreen, DeveloperScreen, ManageProfilesScreen, RestoreWalletScreen } from '../../screens';
+import { AddExistingProfileScreen, DetailsScreen, DeveloperScreen, ManageProfilesScreen, RestoreWalletScreen, CredentialScreen, PublicLinkScreen } from '../../screens';
 import ProfileCredentialScreen from '../../screens/ProfileCredentialScreen';
 import { useAppDispatch, useDynamicStyles, useResetNavigationOnBlur, useThemeContext } from '../../hooks';
 import { SettingsNavigationProps } from '../';
@@ -202,6 +202,8 @@ export default function SettingsNavigation({ navigation }: SettingsNavigationPro
       <Stack.Screen name="ManageProfilesScreen" component={ManageProfilesScreen} />
       <Stack.Screen name="AddExistingProfileScreen" component={AddExistingProfileScreen} />
       <Stack.Screen name="ProfileCredentialScreen" component={ProfileCredentialScreen} />
+      <Stack.Screen name="CredentialScreen" component={CredentialScreen} />
+      <Stack.Screen name="PublicLinkScreen" component={PublicLinkScreen} />
       <Stack.Screen name="DetailsScreen" component={DetailsScreen} />
       <Stack.Screen name="RestoreWalletScreen" component={RestoreWalletScreen} />
       <Stack.Screen name="About" component={About} />

--- a/app/navigation/index.ts
+++ b/app/navigation/index.ts
@@ -22,7 +22,8 @@ export { navigationRef } from './navigationRef';
  */
 import { CredentialScreenHomeProps } from './CredentialNavigation/CredentialNavigation.d';
 import { CredentialScreenShareProps } from './ShareNavigation/ShareNavigation.d';
-export type CredentialScreenProps = CredentialScreenHomeProps | CredentialScreenShareProps;
+import { CredentialScreenSettingsProps } from './SettingsNavigation/SettingsNavigation.d';
+export type CredentialScreenProps = CredentialScreenHomeProps | CredentialScreenShareProps | CredentialScreenSettingsProps;
 
 import { DetailsScreenSettingsProps } from './SettingsNavigation/SettingsNavigation.d';
 import { DetailsScreenSetupProps } from './SetupNavigation/SetupNavigation.d';
@@ -30,7 +31,8 @@ export type DetailsScreenProps = DetailsScreenSettingsProps | DetailsScreenSetup
 
 import { PublicLinkScreenCredentialProps } from './CredentialNavigation/CredentialNavigation.d';
 import { PublicLinkScreenShareProps } from './ShareNavigation/ShareNavigation.d';
-export type PublicLinkScreenProps = PublicLinkScreenCredentialProps | PublicLinkScreenShareProps;
+import { PublicLinkScreenSettingsProps } from './SettingsNavigation/SettingsNavigation.d';
+export type PublicLinkScreenProps = PublicLinkScreenCredentialProps | PublicLinkScreenShareProps | PublicLinkScreenSettingsProps;
 
 import { IssuerInfoScreenCredentialProps } from './CredentialNavigation/CredentialNavigation.d';
 import { IssuerInfoScreenAddProps } from './AcceptCredentialsNavigation/AcceptCredentialsNavigation.d';

--- a/app/screens/CredentialScreen/CredentialScreen.tsx
+++ b/app/screens/CredentialScreen/CredentialScreen.tsx
@@ -33,7 +33,7 @@ export default function CredentialScreen({ navigation, route }: CredentialScreen
   function onPressShare() {
     if (navigationRef.isReady()) {
       navigationRef.navigate('HomeNavigation', {
-        screen: 'CredentialNavigation',
+        screen: 'SettingsNavigation',
         params: {
           screen: 'PublicLinkScreen',
           params: {


### PR DESCRIPTION
Created Pr for #900 

Able to click and go back from the credential preview screen when looking at a profile's credentials, also back from share screen to credential preview screen