### PR TITLE
Fixed dependency error , now "npm install" should work

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.6",
     "react-redux": "^9.1.2",
+    "react-test-renderer": "19.0.0",
     "stream-browserify": "^3.0.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.6",


### PR DESCRIPTION
This task is related to issue #899. 

The issue is that @testing-library/react-native needs react-test-renderer , Added react-test-renderer@19.0.0 explicitly to match React version