### PR TITLE
914: Links disabled for issuers that are in registry

### DIFF
--- a/app/lib/credentialDisplay/openBadgeCredential.tsx
+++ b/app/lib/credentialDisplay/openBadgeCredential.tsx
@@ -40,7 +40,7 @@ const OpenBadgeCredentialCard = ({ rawCredentialRecord }: CredentialCardProps): 
   const { credential } = rawCredentialRecord;
   const verifyCredential = useVerifyCredential(rawCredentialRecord);
   const registries = useContext(DidRegistryContext);
-  const urlsDisabled = shouldDisableUrls(credential, registries);
+  const urlsDisabled = shouldDisableUrls(credential, registries, verifyCredential?.result);
 
   const navigation = useNavigation<NavigationProp>();
 

--- a/app/lib/credentialDisplay/verifiableCredential.tsx
+++ b/app/lib/credentialDisplay/verifiableCredential.tsx
@@ -37,7 +37,7 @@ function VerifiableCredentialCard({ rawCredentialRecord }: CredentialCardProps):
   const { credential } = rawCredentialRecord;
   const verifyCredential = useVerifyCredential(rawCredentialRecord);
   const registries = useContext(DidRegistryContext);
-  const urlsDisabled = shouldDisableUrls(credential, registries);
+  const urlsDisabled = shouldDisableUrls(credential, registries, verifyCredential?.result);
   const navigation = useNavigation<NavigationProp>();
   const { credentialSubject, issuer } = credential;
 

--- a/app/lib/credentialSecurity.ts
+++ b/app/lib/credentialSecurity.ts
@@ -1,15 +1,37 @@
 import type { RegistryClient } from '@digitalcredentials/issuer-registry-client';
 import { issuerInRegistries } from './issuerInRegistries';
 import { IVerifiableCredential } from '@digitalcredentials/ssi';
+import type { ResultLog } from './validate';
+
+type VerificationResultLike = {
+  log?: ResultLog[];
+} | null | undefined;
+
+function issuerRecognizedByVerification(verificationResult?: VerificationResultLike): boolean {
+  if (!Array.isArray(verificationResult?.log)) {
+    return false;
+  }
+
+  return verificationResult.log.some((entry) => {
+    if (entry.id !== 'registered_issuer') return false;
+    const matchingIssuers = (entry as ResultLog & { matchingIssuers?: unknown[] }).matchingIssuers;
+    return entry.valid && Array.isArray(matchingIssuers) ? matchingIssuers.length > 0 : entry.valid;
+  });
+}
 
 /**
  * Determines if URLs should be disabled for a credential
  */
 export function shouldDisableUrls(
   credential: IVerifiableCredential,
-  registries: RegistryClient
+  registries: RegistryClient,
+  verificationResult?: VerificationResultLike
 ): boolean {
   try {
+    if (issuerRecognizedByVerification(verificationResult)) {
+      return false;
+    }
+
     const registryNames = issuerInRegistries({ issuer: credential.issuer, registries });
     const shouldDisable = !registryNames || registryNames.length === 0;
 

--- a/app/screens/ApproveCredentialScreen/ApproveCredentialScreen.tsx
+++ b/app/screens/ApproveCredentialScreen/ApproveCredentialScreen.tsx
@@ -22,7 +22,7 @@ export default function ApproveCredentialScreen({ navigation, route }: ApproveCr
   const rawCredentialRecord = useMemo(() => CredentialRecord.rawFrom({ credential, profileRecordId }), [credential]);
   const verifyPayload = useVerifyCredential(rawCredentialRecord, true);
   const registries = useContext(DidRegistryContext);
-  const urlsDisabled = shouldDisableUrls(credential, registries);
+  const urlsDisabled = shouldDisableUrls(credential, registries, verifyPayload?.result);
 
   function goToIssuerInfo(issuerId: string) {
     if (navigationRef.isReady()) {

--- a/app/screens/IssuerInfoScreen/IssuerInfoScreen.tsx
+++ b/app/screens/IssuerInfoScreen/IssuerInfoScreen.tsx
@@ -21,7 +21,7 @@ export default function IssuerInfoScreen({
   const verifyCredential = useVerifyCredential(rawCredentialRecord);
   const credential = rawCredentialRecord.credential;
   const registries = useContext(DidRegistryContext);
-  const urlsDisabled = shouldDisableUrls(credential, registries);
+  const urlsDisabled = shouldDisableUrls(credential, registries, verifyCredential?.result);
 
   const getImageUri = (img?: string | { id?: string }): string | undefined => {
     if (!img) return undefined;

--- a/test/credentialSecurity.test.ts
+++ b/test/credentialSecurity.test.ts
@@ -45,5 +45,33 @@ describe('credentialSecurity', () => {
       
       expect(result).toBe(true);
     });
+
+    it('should return false when verification confirms registered issuer', () => {
+      (issuerInRegistries as jest.Mock).mockReturnValue(null);
+
+      const verificationResult = {
+        log: [
+          { id: 'registered_issuer', valid: true, matchingIssuers: [{}] },
+        ],
+      };
+
+      const result = shouldDisableUrls(mockCredential, mockRegistries, verificationResult as any);
+
+      expect(result).toBe(false);
+    });
+
+    it('should ignore verification log entries that are invalid', () => {
+      (issuerInRegistries as jest.Mock).mockReturnValue([]);
+
+      const verificationResult = {
+        log: [
+          { id: 'registered_issuer', valid: false, matchingIssuers: [] },
+        ],
+      };
+
+      const result = shouldDisableUrls(mockCredential, mockRegistries, verificationResult as any);
+
+      expect(result).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Created PR for #914 

Short circuiting shouldDisableUrls when the verification log already says registered_issuer, avoids redundant registry lookups and keeps the UX aligned with what verification knows in real time

<img width="1231" height="1027" alt="Screenshot 2025-11-26 at 2 42 22 PM" src="https://github.com/user-attachments/assets/c8cd5022-cacb-4176-9b53-a3b9a738e38d" />
