### PR TITLE
915 cannot select profile when adding mock credential after going back one screen

### DIFF
--- a/app/mock/credential.ts
+++ b/app/mock/credential.ts
@@ -261,12 +261,7 @@ export const rawVcRecords: CredentialRecordRaw[] = [
   }
 ]
 
-const credentials = [
-  mockCredential,
-  mockCredential2
-  // studentCard,
-  // anotherCred,
-]
+const credentials = [mockCredential, mockCredential2]
 
 export default mockCredential
 export { credentials }

--- a/app/navigation/AcceptCredentialsNavigation/AcceptCredentialsNavigation.d.ts
+++ b/app/navigation/AcceptCredentialsNavigation/AcceptCredentialsNavigation.d.ts
@@ -8,6 +8,7 @@ export type AcceptCredentialsNavigationParamList = {
   ApproveCredentialsScreen: {
     credentialRequestParams?: CredentialRequestParams
     rawProfileRecord: ProfileRecordRaw
+    canGoBack?: boolean
   }
   ApproveCredentialScreen: {
     pendingCredentialId: string

--- a/app/navigation/RootNavigation/RootNavigation.tsx
+++ b/app/navigation/RootNavigation/RootNavigation.tsx
@@ -29,6 +29,9 @@ export default function RootNavigation(): React.ReactElement {
       <Stack.Screen
         name="AcceptCredentialsNavigation"
         component={AcceptCredentialsNavigation}
+        options={{
+          gestureEnabled: false
+        }}
       />
       <Stack.Screen
         name="ExchangeCredentialsNavigation"

--- a/app/screens/DeveloperScreen/DeveloperScreen.tsx
+++ b/app/screens/DeveloperScreen/DeveloperScreen.tsx
@@ -9,7 +9,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { NavHeader } from '../../components'
 import dynamicStyleSheet from './DeveloperScreen.styles'
 import { DeveloperScreenProps } from './DeveloperScreen.d'
-import { stageCredentials } from '../../store/slices/credentialFoyer'
+import { stageCredentialsForProfile } from '../../store/slices/credentialFoyer'
 import { credentials } from '../../mock/credential'
 import { navigationRef } from '../../navigation/navigationRef'
 import { Cache, CacheKey } from '../../lib/cache'
@@ -48,26 +48,40 @@ export default function DeveloperScreen({
     titleStyle: mixins.buttonIconTitle
   }
 
-  async function goToApproveCredentials() {
-    if (navigationRef.isReady()) {
+  async function addMockCredentials() {
+    try {
       const rawProfileRecord = await NavigationUtil.selectProfile()
+      await dispatch(
+        stageCredentialsForProfile({
+          credentials,
+          profileRecordId: rawProfileRecord._id
+        })
+      ).unwrap()
       navigationRef.navigate('AcceptCredentialsNavigation', {
         screen: 'ApproveCredentialsScreen',
-        params: {
-          rawProfileRecord
-        }
+        params: { rawProfileRecord, canGoBack: true }
       })
+    } catch (error) {
+      console.error('Error adding mock credentials:', error)
     }
   }
 
-  async function addMockCredentials() {
-    await dispatch(stageCredentials(credentials))
-    goToApproveCredentials()
-  }
-
   async function addRevokedCredential() {
-    await dispatch(stageCredentials([revokedCredential]))
-    goToApproveCredentials()
+    try {
+      const rawProfileRecord = await NavigationUtil.selectProfile()
+      await dispatch(
+        stageCredentialsForProfile({
+          credentials: [revokedCredential],
+          profileRecordId: rawProfileRecord._id
+        })
+      ).unwrap()
+      navigationRef.navigate('AcceptCredentialsNavigation', {
+        screen: 'ApproveCredentialsScreen',
+        params: { rawProfileRecord, canGoBack: true }
+      })
+    } catch (error) {
+      console.error('Error adding revoked credential:', error)
+    }
   }
 
   function receiveCredentialThroughDeepLink() {

--- a/app/screens/ProfileSelectionScreen/ProfileSelectionScreen.tsx
+++ b/app/screens/ProfileSelectionScreen/ProfileSelectionScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useCallback } from 'react'
 import { FlatList, Text, View } from 'react-native'
 import { Button, ListItem } from 'react-native-elements'
 
@@ -11,6 +11,7 @@ import { NavHeader } from '../../components'
 import { useSelector } from 'react-redux'
 import { selectRawProfileRecords } from '../../store/slices/profile'
 import { useDynamicStyles, useSelectorFactory } from '../../hooks'
+import { ProfileRecordRaw } from '../../model'
 
 import { makeSelectProfileForPendingCredentials } from '../../store/selectorFactories/makeSelectProfileForPendingCredentials'
 
@@ -35,15 +36,25 @@ export default function ProfileSelectionScreen({
     [rawProfileRecords]
   )
 
+  const hasAutoSelected = useRef(false)
+
+  const handleSelectProfile = useCallback(
+    (profile: ProfileRecordRaw) => {
+      hasAutoSelected.current = true
+      onSelectProfile(profile)
+    },
+    [onSelectProfile]
+  )
+
   useEffect(() => {
-    console.log('Profile records:', rawProfileRecords)
+    if (hasAutoSelected.current) return
 
     if (associatedProfile) {
-      onSelectProfile(associatedProfile)
+      handleSelectProfile(associatedProfile)
     } else if (rawProfileRecords.length === 1) {
-      onSelectProfile(rawProfileRecords[0])
+      handleSelectProfile(rawProfileRecords[0])
     }
-  }, [associatedProfile, rawProfileRecords, onSelectProfile])
+  }, [associatedProfile, rawProfileRecords, handleSelectProfile])
 
   const ListHeader = (
     <View style={styles.listHeader}>
@@ -61,7 +72,7 @@ export default function ProfileSelectionScreen({
         renderItem={({ item }) => (
           <ProfileButton
             rawProfileRecord={item}
-            onPress={() => onSelectProfile(item)}
+            onPress={() => handleSelectProfile(item)}
           />
         )}
       />

--- a/app/screens/ProfileSelectionScreen/ProfileSelectionScreen.tsx
+++ b/app/screens/ProfileSelectionScreen/ProfileSelectionScreen.tsx
@@ -47,6 +47,8 @@ export default function ProfileSelectionScreen({
   )
 
   useEffect(() => {
+    console.log('Profile records:', rawProfileRecords)
+
     if (hasAutoSelected.current) return
 
     if (associatedProfile) {

--- a/app/store/slices/credentialFoyer.ts
+++ b/app/store/slices/credentialFoyer.ts
@@ -5,7 +5,7 @@ import { canonicalize as jcsCanonicalize } from 'json-canonicalize'
 import { CredentialRecord } from '../../model/credential'
 
 import { RootState } from '..'
-import { addCredential } from './credential'
+import { addCredential, deleteCredential } from './credential'
 import { ObjectID } from 'bson'
 import { IVerifiableCredential } from '@digitalcredentials/ssi'
 import { credentialContentHash } from '../../lib/credentialHash'
@@ -238,6 +238,10 @@ const credentialFoyer = createSlice({
 
     builder.addCase(acceptPendingCredentials.rejected, (_, action) => {
       throw action.error
+    })
+
+    builder.addCase(deleteCredential.fulfilled, (state) => {
+      return state
     })
   }
 })

--- a/test/ApproveCredentialsScreen.test.tsx
+++ b/test/ApproveCredentialsScreen.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn()
+}))
+
+jest.mock('../app/hooks', () => ({
+  useAppDispatch: jest.fn(),
+  useDynamicStyles: jest.fn()
+}))
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn()
+}))
+
+jest.mock('../app/navigation/navigationRef', () => ({
+  navigationRef: { navigate: jest.fn(), isReady: jest.fn(() => true) }
+}))
+
+jest.mock('../app/store/slices/credentialFoyer', () => ({
+  selectPendingCredentials: jest.fn(),
+  clearFoyer: jest.fn(),
+  acceptPendingCredentials: jest.fn(),
+  setCredentialApproval: jest.fn(),
+  ApprovalStatus: { Pending: 0, PendingDuplicate: 1, Accepted: 2, Rejected: 3 }
+}))
+
+jest.mock('../app/model/credential', () => ({
+  CredentialRecord: { getAllCredentialRecords: jest.fn() }
+}))
+
+jest.mock('../app/components/NavHeader/NavHeader', () => 'NavHeader')
+jest.mock(
+  '../app/components/CredentialItem/CredentialItem',
+  () => 'CredentialItem'
+)
+jest.mock(
+  '../app/components/ApprovalControls/ApprovalControls',
+  () => 'ApprovalControls'
+)
+jest.mock(
+  '../app/components/CredentialRequestHandler/CredentialRequestHandler',
+  () => 'CredentialRequestHandler'
+)
+jest.mock('../app/components/ConfirmModal/ConfirmModal', () => 'ConfirmModal')
+
+import ApproveCredentialsScreen from '../app/screens/ApproveCredentialsScreen/ApproveCredentialsScreen'
+
+describe('ApproveCredentialsScreen', () => {
+  const mockDispatch = jest.fn()
+  const mockNavigation: any = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    getParent: jest.fn()
+  }
+  const mockRoute: any = {
+    params: {
+      rawProfileRecord: { _id: 'profile1', profileName: 'Test Profile' },
+      canGoBack: true
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const { useAppDispatch, useDynamicStyles } = require('../app/hooks')
+    const { useSelector } = require('react-redux')
+
+    useAppDispatch.mockReturnValue(mockDispatch)
+    useDynamicStyles.mockReturnValue({
+      styles: {},
+      mixins: {}
+    })
+    useSelector.mockReturnValue([])
+  })
+
+  it('renders with canGoBack true', () => {
+    const { UNSAFE_root } = render(
+      <ApproveCredentialsScreen navigation={mockNavigation} route={mockRoute} />
+    )
+    expect(UNSAFE_root).toBeTruthy()
+  })
+
+  it('renders without canGoBack', () => {
+    const routeWithoutGoBack: any = {
+      params: {
+        rawProfileRecord: { _id: 'profile1', profileName: 'Test Profile' },
+        canGoBack: false
+      }
+    }
+    const { UNSAFE_root } = render(
+      <ApproveCredentialsScreen
+        navigation={mockNavigation}
+        route={routeWithoutGoBack}
+      />
+    )
+    expect(UNSAFE_root).toBeTruthy()
+  })
+
+  it('filters pending credentials correctly', () => {
+    const { useSelector } = require('react-redux')
+    const { ApprovalStatus } = require('../app/store/slices/credentialFoyer')
+
+    const mockCredentials = [
+      { id: '1', status: ApprovalStatus.Pending },
+      { id: '2', status: ApprovalStatus.PendingDuplicate },
+      { id: '3', status: ApprovalStatus.Accepted }
+    ]
+
+    useSelector.mockReturnValue(mockCredentials)
+
+    const { UNSAFE_root } = render(
+      <ApproveCredentialsScreen navigation={mockNavigation} route={mockRoute} />
+    )
+    expect(UNSAFE_root).toBeTruthy()
+  })
+
+  it('shows Accept button when only one acceptable credential', () => {
+    const { useSelector } = require('react-redux')
+    const { ApprovalStatus } = require('../app/store/slices/credentialFoyer')
+
+    useSelector.mockReturnValue([{ id: '1', status: ApprovalStatus.Pending }])
+
+    const { UNSAFE_root } = render(
+      <ApproveCredentialsScreen navigation={mockNavigation} route={mockRoute} />
+    )
+    expect(UNSAFE_root).toBeTruthy()
+  })
+
+  it('shows Accept All button when multiple acceptable credentials', () => {
+    const { useSelector } = require('react-redux')
+    const { ApprovalStatus } = require('../app/store/slices/credentialFoyer')
+
+    useSelector.mockReturnValue([
+      { id: '1', status: ApprovalStatus.Pending },
+      { id: '2', status: ApprovalStatus.Pending }
+    ])
+
+    const { UNSAFE_root } = render(
+      <ApproveCredentialsScreen navigation={mockNavigation} route={mockRoute} />
+    )
+    expect(UNSAFE_root).toBeTruthy()
+  })
+
+  it('does not show Accept All button when only duplicates', () => {
+    const { useSelector } = require('react-redux')
+    const { ApprovalStatus } = require('../app/store/slices/credentialFoyer')
+
+    useSelector.mockReturnValue([
+      { id: '1', status: ApprovalStatus.PendingDuplicate }
+    ])
+
+    const { UNSAFE_root } = render(
+      <ApproveCredentialsScreen navigation={mockNavigation} route={mockRoute} />
+    )
+    expect(UNSAFE_root).toBeTruthy()
+  })
+})

--- a/test/ProfileSelectionScreen.test.tsx
+++ b/test/ProfileSelectionScreen.test.tsx
@@ -252,4 +252,69 @@ describe('ProfileSelectionScreen', () => {
     )
     expect(UNSAFE_root).toBeTruthy()
   })
+
+  it('sets hasAutoSelected flag when profile is manually selected', () => {
+    const { getByTestId } = render(
+      <ProfileSelectionScreen navigation={mockNavigation} route={mockRoute} />
+    )
+
+    const profileBtn = getByTestId('button-Profile 1')
+    fireEvent.press(profileBtn)
+    expect(mockOnSelectProfile).toHaveBeenCalledTimes(1)
+    expect(mockOnSelectProfile).toHaveBeenCalledWith(mockProfiles[0])
+  })
+
+  it('does not auto-select again after manual selection', () => {
+    const { useSelector } = require('react-redux')
+    const { rerender } = render(
+      <ProfileSelectionScreen navigation={mockNavigation} route={mockRoute} />
+    )
+
+    // Simulate manual selection
+    const { getByTestId } = render(
+      <ProfileSelectionScreen navigation={mockNavigation} route={mockRoute} />
+    )
+    const profileBtn = getByTestId('button-Profile 1')
+    fireEvent.press(profileBtn)
+
+    // Clear mock to check if auto-select happens again
+    mockOnSelectProfile.mockClear()
+
+    // Update profiles (simulating navigation back)
+    useSelector.mockReturnValue(mockProfiles)
+    rerender(
+      <ProfileSelectionScreen navigation={mockNavigation} route={mockRoute} />
+    )
+
+    // Should not auto-select again
+    expect(mockOnSelectProfile).not.toHaveBeenCalled()
+  })
+
+  it('handleSelectProfile is memoized with useCallback', () => {
+    const { rerender } = render(
+      <ProfileSelectionScreen navigation={mockNavigation} route={mockRoute} />
+    )
+
+    const firstCallCount = mockOnSelectProfile.mock.calls.length
+
+    // Re-render with same props
+    rerender(
+      <ProfileSelectionScreen navigation={mockNavigation} route={mockRoute} />
+    )
+
+    // Should not cause additional calls if properly memoized
+    expect(mockOnSelectProfile.mock.calls.length).toBe(firstCallCount)
+  })
+
+  it('calls handleSelectProfile for both auto and manual selection', () => {
+    const { useSelector } = require('react-redux')
+    useSelector.mockReturnValue([mockProfiles[0]])
+
+    const { getByTestId } = render(
+      <ProfileSelectionScreen navigation={mockNavigation} route={mockRoute} />
+    )
+
+    // Auto-select should have been called
+    expect(mockOnSelectProfile).toHaveBeenCalledWith(mockProfiles[0])
+  })
 })


### PR DESCRIPTION
Created PR for #915 

AC1: Swiping left should not affect ability to choose profile (navigates back to Settings screen to select profile again)
AC2: Add "go back" arrow to "Available Credentials" screen
AC3: Show credentials to add without grey text for duplicates in other profiles
AC4: Show appropriate message for credentials that exist in selected profile
AC5: Deleting a credential should update the available credentials page
AC6: Dynamic "Accept" button text

## Screenshots
<img width="562" height="1018" alt="Screenshot 2025-12-09 at 4 52 10 PM" src="https://github.com/user-attachments/assets/f945b0e9-bfe2-4602-bfec-a69f1fd5cedd" />
<img width="562" height="1018" alt="Screenshot 2025-12-09 at 4 52 22 PM" src="https://github.com/user-attachments/assets/6a5b68fd-2134-4b56-a153-d69f6b1773f9" />

