### PR TITLE
Remove unused registry param from credential verification

### DIFF
--- a/app/hooks/useVerifyCredential.ts
+++ b/app/hooks/useVerifyCredential.ts
@@ -1,8 +1,7 @@
-import { useCallback, useContext, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { CredentialError } from '../types/credential'
 import { CredentialRecordRaw } from '../model'
 import { useFocusEffect } from '@react-navigation/native'
-import { DidRegistryContext } from '../init/registries'
 import { VerifyPayload, verificationResultFor } from '../lib/verifiableObject'
 
 const DEFAULT_ERROR_MESSAGE =
@@ -19,8 +18,6 @@ export function useVerifyCredential(
   const [result, setResult] = useState<VerifyPayload['result']>(initialResult)
   const [error, setError] = useState<VerifyPayload['error']>(null)
 
-  const registries = useContext(DidRegistryContext)
-
   if (rawCredentialRecord === undefined) {
     return null
   }
@@ -29,8 +26,7 @@ export function useVerifyCredential(
     try {
       const verificationResult = await verificationResultFor({
         rawCredentialRecord,
-        forceFresh,
-        registries
+        forceFresh
       })
       setResult(verificationResult)
 
@@ -49,7 +45,7 @@ export function useVerifyCredential(
     } finally {
       setLoading(false)
     }
-  }, [rawCredentialRecord, forceFresh, registries]) // require update when these values changes
+  }, [rawCredentialRecord, forceFresh])
 
   useFocusEffect(
     useCallback(() => {

--- a/app/lib/verifiableObject.ts
+++ b/app/lib/verifiableObject.ts
@@ -5,7 +5,6 @@ import {
   ResultLog,
   verifyCredential
 } from './validate'
-import { RegistryClient } from '@digitalcredentials/issuer-registry-client'
 import { CredentialRecordRaw } from '../model'
 import {
   IVerifiableCredential,
@@ -60,7 +59,6 @@ export async function verificationResultFor({
 }: {
   rawCredentialRecord: CredentialRecordRaw
   forceFresh?: boolean
-  registries: RegistryClient
 }): Promise<VerificationResult> {
   const cachedRecordId = String(rawCredentialRecord._id)
 

--- a/app/screens/CredentialSelectionScreen/CredentialSelectionScreen.tsx
+++ b/app/screens/CredentialSelectionScreen/CredentialSelectionScreen.tsx
@@ -61,8 +61,7 @@ export default function CredentialSelectionScreen({
         try {
           const res = await verificationResultFor({
             rawCredentialRecord: r,
-            forceFresh: false,
-            registries: undefined as any
+            forceFresh: false
           })
           entries[String(r._id)] = res
           publicEntries[String(r._id)] = await hasPublicLink(r)

--- a/app/screens/HomeScreen/HomeScreen.tsx
+++ b/app/screens/HomeScreen/HomeScreen.tsx
@@ -19,10 +19,6 @@ import {
   selectRawCredentialRecords
 } from '../../store/slices/credential'
 import { getCredentialName } from '../../lib/credentialName'
-import { verificationResultFor } from '../../lib/verifiableObject'
-import { displayGlobalModal } from '../../lib/globalModal'
-import { useContext } from 'react'
-import { DidRegistryContext } from '../../init/registries'
 
 export default function HomeScreen({
   navigation
@@ -35,7 +31,6 @@ export default function HomeScreen({
   )
   const dispatch = useAppDispatch()
   const share = useShareCredentials()
-  const registries = useContext(DidRegistryContext)
 
   const itemToDeleteName = itemToDelete
     ? getCredentialName(itemToDelete.credential)

--- a/app/screens/PresentationPreviewScreen/PresentationPreviewScreen.tsx
+++ b/app/screens/PresentationPreviewScreen/PresentationPreviewScreen.tsx
@@ -16,7 +16,7 @@ import {
 import dynamicStyleSheet from './PresentationPreviewScreen.styles'
 import type { PresentationPreviewScreenProps } from '../../navigation'
 import type { RenderItemProps } from './PresentationPreviewScreen.d'
-import { useDynamicStyles, useVerifyCredential } from '../../hooks'
+import { useDynamicStyles } from '../../hooks'
 import { useShareCredentials } from '../../hooks/useShareCredentials'
 import { PublicLinkScreenMode } from '../PublicLinkScreen/PublicLinkScreen'
 import { displayGlobalModal, clearGlobalModal } from '../../lib/globalModal'
@@ -24,9 +24,6 @@ import { createPublicLinkFor, getPublicViewLink } from '../../lib/publicLink'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - app.config.js doesn't have type declarations
 import { LinkConfig } from '../../../app.config'
-import { verificationResultFor } from '../../lib/verifiableObject'
-import { useContext } from 'react'
-import { DidRegistryContext } from '../../init/registries'
 
 export default function PresentationPreviewScreen({
   navigation,
@@ -35,7 +32,6 @@ export default function PresentationPreviewScreen({
   const { styles, mixins } = useDynamicStyles(dynamicStyleSheet)
   const { selectedCredentials, mode = 'send' } = route.params
   const share = useShareCredentials()
-  const registries = useContext(DidRegistryContext)
 
   const isCreateLinkMode = mode === 'createLink'
   const buttonTitle = isCreateLinkMode ? 'Create Public Link' : 'Send'

--- a/test/HomeScreen.test.tsx
+++ b/test/HomeScreen.test.tsx
@@ -149,42 +149,10 @@ jest.mock('../app.config', () => ({
   LinkConfig: {
     appWebsite: {
       home: 'https://lcw.app',
-      faq: 'https://lcw.app/faq',
-    },
-  },
-}));
-
-jest.mock('../app/lib/verifiableObject', () => ({
-  verificationResultFor: jest.fn(() => Promise.resolve({
-    verified: true,
-    log: [
-      { id: 'valid_signature', valid: true },
-      { id: 'expiration', valid: true },
-      { id: 'registered_issuer', valid: true },
-      { id: 'revocation_status', valid: true },
-    ],
-    timestamp: Date.now(),
-  })),
-}));
-
-// credentialVerificationStatus module removed - all credentials can now be shared
-
-jest.mock('../app/lib/globalModal', () => ({
-  displayGlobalModal: jest.fn(() => Promise.resolve(true)),
-}));
-
-jest.mock('../app/init/registries', () => ({
-  DidRegistryContext: {
-    Provider: ({ children }: any) => children,
-    Consumer: ({ children }: any) => children({}),
-  },
-}));
-
-// Mock useContext to return a mock registry
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useContext: jest.fn(() => ({})),
-}));
+      faq: 'https://lcw.app/faq'
+    }
+  }
+}))
 
 import HomeScreen from '../app/screens/HomeScreen/HomeScreen'
 


### PR DESCRIPTION
- The registries argument on verificationResultFor was never read.
- Clean up the dead plumbing in callers.
- Delete orphaned HomeScreen test mocks